### PR TITLE
fix(Makefile) solve the problem of tls.lua placement path error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 OPENRESTY_PREFIX=/usr/local/openresty
 
 #LUA_VERSION := 5.1
-PREFIX ?=          /usr/local
-LUA_INCLUDE_DIR ?= $(PREFIX)/include
-LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
+#PREFIX ?=          /usr/local
+#LUA_INCLUDE_DIR ?= $(PREFIX)/include
+LUA_LIB_DIR ?=     $(OPENRESTY_PREFIX)/lualib
 INSTALL ?= install
 
 .PHONY: all test install
@@ -11,5 +11,5 @@ INSTALL ?= install
 all: ;
 
 install: all
-	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/resty/kong/
-	$(INSTALL) -m 664 lualib/resty/kong/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/kong/
+	$(INSTALL) -d $(LUA_LIB_DIR)/resty/kong/
+	$(INSTALL) -m 664 lualib/resty/kong/*.lua $(LUA_LIB_DIR)/resty/kong/


### PR DESCRIPTION
The default Makefile can't install tls.lua to correct package.path.

Refer to the latest container image of kong1.3.0 version, modify Makfile to solve the problem of tls.lua placement path error.


Signed-off-by: bevisy <binbin36520@gmail.com>