### PR TITLE
fix(set_upstream_ssl_trusted_store) use correct type for

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ resty.kong.tls.set\_upstream\_ssl\_trusted\_store
 Set upstream ssl verification trusted store of current request. Global setting set by
 `proxy_ssl_trusted_certificate` will be overwritten for the current request.
 
-`store` is a `X509_STORE*` cdata that can be created by
+`store` is a table object that can be created by
 [resty.openssl.x509.store.new](https://github.com/fffonion/lua-resty-openssl#storenew).
 
 On success, this function returns `true` and future handshakes with upstream servers

--- a/t/002-upstream-tls.t
+++ b/t/002-upstream-tls.t
@@ -651,7 +651,7 @@ X509_check_host(): match
                 f:close()
                 assert(s:add(x509.new(cert_data)))
             end
-            local ok, err = tls.set_upstream_ssl_trusted_store(s.ctx)
+            local ok, err = tls.set_upstream_ssl_trusted_store(s)
             if not ok then
                 ngx.say("set_upstream_ssl_trusted_store failed: ", err)
             end
@@ -718,7 +718,7 @@ upstream SSL certificate verify error: (2:unable to get issuer certificate)
                 f:close()
                 assert(s:add(x509.new(cert_data)))
             end
-            local ok, err = tls.set_upstream_ssl_trusted_store(s.ctx)
+            local ok, err = tls.set_upstream_ssl_trusted_store(s)
             if not ok then
                 ngx.say("set_upstream_ssl_trusted_store failed: ", err)
             end
@@ -786,7 +786,7 @@ X509_check_host(): match
                 assert(s:add(x509.new(cert_data)))
             end
             for i=0,3 do
-                local ok, err = tls.set_upstream_ssl_trusted_store(s.ctx)
+                local ok, err = tls.set_upstream_ssl_trusted_store(s)
                 if not ok then
                     ngx.say("set_upstream_ssl_trusted_store failed: ", err)
                     return


### PR DESCRIPTION
resty.openssl.x509.store object checks