### PR TITLE
chore(*) add couple of functions for better macOS+M1 support

### DIFF
--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -885,3 +885,40 @@ nomem:
     *err = "no memory";
     return NGX_ERROR;
 }
+
+// macOS with M1 fixes, see: https://github.com/LuaJIT/LuaJIT/issues/205
+
+int
+ngx_http_lua_ffi_shdict_get_m1(ngx_shdict_get_t *s)
+{
+    return ngx_http_lua_ffi_shdict_get(s->zone, s->key, s->key_len, s->value_type,
+        s->str_value_buf, s->str_value_len, s->num_value, s->user_flags, s->get_stale,
+        s->is_stale, s->errmsg);
+}
+
+
+int
+ngx_http_lua_ffi_shdict_store_m1(ngx_shdict_store_t *s)
+{
+    return ngx_http_lua_ffi_shdict_store(s->zone, s->op, s->key, s->key_len, s->value_type,
+        s->str_value_buf, s->str_value_len, s->num_value, s->exptime, s->user_flags, s->errmsg,
+        s->forcible);
+}
+
+
+int
+ngx_http_lua_ffi_shdict_incr_m1(ngx_shdict_incr_t *s)
+{
+    return ngx_http_lua_ffi_shdict_incr(s->zone, s->key, s->key_len, s->num_value,
+        s->errmsg, s->has_init, s->init, s->init_ttl, s->forcible);
+}
+
+
+int
+ngx_http_lua_ffi_set_resp_header_m1(ngx_set_resp_header_t *s)
+{
+    return ngx_http_lua_ffi_set_resp_header(s->r, s->key_data, s->key_len, s->is_nil,
+        s->sval, s->sval_len, s->mvals, s->mvals_len, s->override, s->errmsg);
+}
+
+// macOS with M1 fixes end

--- a/src/ngx_http_lua_kong_module.h
+++ b/src/ngx_http_lua_kong_module.h
@@ -32,4 +32,94 @@ ngx_http_lua_kong_get_upstream_ssl_verify(ngx_http_request_t *r,
     ngx_flag_t proxy_ssl_verify);
 
 
+// macOS with M1 fixes, see: https://github.com/LuaJIT/LuaJIT/issues/205
+
+int ngx_http_lua_ffi_shdict_get(ngx_shm_zone_t *zone, const unsigned char *key,
+    size_t key_len, int *value_type, unsigned char **str_value_buf,
+    size_t *str_value_len, double *num_value, int *user_flags,
+    int get_stale, int *is_stale, char **errmsg);
+
+typedef struct {
+    ngx_shm_zone_t *zone;
+    const unsigned char *key;
+    size_t key_len;
+    int *value_type;
+    unsigned char **str_value_buf;
+    size_t *str_value_len;
+    double *num_value;
+    int *user_flags;
+    int get_stale;
+    int *is_stale;
+    char **errmsg;
+} ngx_shdict_get_t;
+
+int ngx_http_lua_ffi_shdict_get_m1(ngx_shdict_get_t *s);
+
+
+int ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op,
+    const unsigned char *key, size_t key_len, int value_type,
+    const unsigned char *str_value_buf, size_t str_value_len,
+    double num_value, long exptime, int user_flags, char **errmsg,
+    int *forcible);
+
+typedef struct {
+    ngx_shm_zone_t *zone;
+    int op;
+    const unsigned char *key;
+    size_t key_len;
+    int value_type;
+    const unsigned char *str_value_buf;
+    size_t str_value_len;
+    double num_value;
+    long exptime;
+    int user_flags;
+    char **errmsg;
+    int *forcible;
+} ngx_shdict_store_t;
+
+int ngx_http_lua_ffi_shdict_store_m1(ngx_shdict_store_t *s);
+
+
+int ngx_http_lua_ffi_shdict_incr(ngx_shm_zone_t *zone, const unsigned char *key,
+    size_t key_len, double *num_value, char **errmsg, int has_init,
+    double init, long init_ttl, int *forcible);
+
+typedef struct {
+    ngx_shm_zone_t *zone;
+    const unsigned char *key;
+    size_t key_len;
+    double *num_value;
+    char **errmsg;
+    int has_init;
+    double init;
+    long init_ttl;
+    int *forcible;
+} ngx_shdict_incr_t;
+
+int ngx_http_lua_ffi_shdict_incr_m1(ngx_shdict_incr_t *s);
+
+
+int ngx_http_lua_ffi_set_resp_header(ngx_http_request_t *r,
+    const char *key_data, size_t key_len, int is_nil,
+    const char *sval, size_t sval_len, void *mvals,
+    size_t mvals_len, int override, char **errmsg);
+
+typedef struct {
+    ngx_http_request_t *r;
+    const char *key_data;
+    size_t key_len;
+    int is_nil;
+    const char *sval;
+    size_t sval_len;
+    void *mvals;
+    size_t mvals_len;
+    int override;
+    char **errmsg;
+} ngx_set_resp_header_t;
+
+int ngx_http_lua_ffi_set_resp_header_m1(ngx_set_resp_header_t *s);
+
+// macOS with M1 fixes end
+
+
 #endif /* _NGX_HTTP_LUA_KONG_MODULE_H_INCLUDED_ */

--- a/stream/src/ngx_stream_lua_kong_module.c
+++ b/stream/src/ngx_stream_lua_kong_module.c
@@ -85,4 +85,34 @@ ngx_stream_lua_kong_get_proxy_ssl_disable(ngx_stream_session_t *s)
 }
 
 
+// macOS with M1 fixes, see: https://github.com/LuaJIT/LuaJIT/issues/205
+
+int
+ngx_stream_lua_ffi_shdict_get_m1(ngx_shdict_get_t *s)
+{
+    return ngx_stream_lua_ffi_shdict_get(s->zone, s->key, s->key_len, s->value_type,
+        s->str_value_buf, s->str_value_len, s->num_value, s->user_flags, s->get_stale,
+        s->is_stale, s->errmsg);
+}
+
+
+int
+ngx_stream_lua_ffi_shdict_store_m1(ngx_shdict_store_t *s)
+{
+    return ngx_stream_lua_ffi_shdict_store(s->zone, s->op, s->key, s->key_len, s->value_type,
+        s->str_value_buf, s->str_value_len, s->num_value, s->exptime, s->user_flags, s->errmsg,
+        s->forcible);
+}
+
+
+int
+ngx_stream_lua_ffi_shdict_incr_m1(ngx_shdict_incr_t *s)
+{
+    return ngx_stream_lua_ffi_shdict_incr(s->zone, s->key, s->key_len, s->num_value,
+        s->errmsg, s->has_init, s->init, s->init_ttl, s->forcible);
+}
+
+// macOS with M1 fixes end
+
+
 #endif

--- a/stream/src/ngx_stream_lua_kong_module.h
+++ b/stream/src/ngx_stream_lua_kong_module.h
@@ -17,6 +17,76 @@ typedef struct {
 ngx_uint_t
 ngx_stream_lua_kong_get_proxy_ssl_disable(ngx_stream_session_t *s);
 
+
+// macOS with M1 fixes, see: https://github.com/LuaJIT/LuaJIT/issues/205
+
+int ngx_stream_lua_ffi_shdict_get(ngx_shm_zone_t *zone, const unsigned char *key,
+    size_t key_len, int *value_type, unsigned char **str_value_buf,
+    size_t *str_value_len, double *num_value, int *user_flags,
+    int get_stale, int *is_stale, char **errmsg);
+
+typedef struct {
+    ngx_shm_zone_t *zone;
+    const unsigned char *key;
+    size_t key_len;
+    int *value_type;
+    unsigned char **str_value_buf;
+    size_t *str_value_len;
+    double *num_value;
+    int *user_flags;
+    int get_stale;
+    int *is_stale;
+    char **errmsg;
+} ngx_shdict_get_t;
+
+int ngx_stream_lua_ffi_shdict_get_m1(ngx_shdict_get_t *s);
+
+
+int ngx_stream_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op,
+    const unsigned char *key, size_t key_len, int value_type,
+    const unsigned char *str_value_buf, size_t str_value_len,
+    double num_value, long exptime, int user_flags, char **errmsg,
+    int *forcible);
+
+typedef struct {
+    ngx_shm_zone_t *zone;
+    int op;
+    const unsigned char *key;
+    size_t key_len;
+    int value_type;
+    const unsigned char *str_value_buf;
+    size_t str_value_len;
+    double num_value;
+    long exptime;
+    int user_flags;
+    char **errmsg;
+    int *forcible;
+} ngx_shdict_store_t;
+
+int ngx_stream_lua_ffi_shdict_store_m1(ngx_shdict_store_t *s);
+
+
+int ngx_stream_lua_ffi_shdict_incr(ngx_shm_zone_t *zone, const unsigned char *key,
+    size_t key_len, double *num_value, char **errmsg, int has_init,
+    double init, long init_ttl, int *forcible);
+
+typedef struct {
+    ngx_shm_zone_t *zone;
+    const unsigned char *key;
+    size_t key_len;
+    double *num_value;
+    char **errmsg;
+    int has_init;
+    double init;
+    long init_ttl;
+    int *forcible;
+} ngx_shdict_incr_t;
+
+int ngx_stream_lua_ffi_shdict_incr_m1(ngx_shdict_incr_t *s);
+
+// macOS with M1 fixes end
+
+
 #endif
 
 #endif /* _NGX_STREAM_LUA_KONG_MODULE_H_INCLUDED_ */


### PR DESCRIPTION
### Summary

There is a LuaJIT bug that is not yet resolved and it causes issues with function calls on macOS+M1. Apple has decided to
break ABI compatibility with ARM64, and thus here we workaround the issue described here:

https://github.com/LuaJIT/LuaJIT/issues/205

Proper fix is to fix LuaJIT, but as that issue has been open since 2016, I thought it would probably be faster to fix this with couple of forward declarations.

This also needs changes in `resty.core.shdict` and `resty.core.response` to take advantage of these new functions. New functions just take struct in and forward the call on C-side to original functions. The issue arises with macOS+M1 if functions have around 8+ arguments. I will link this issue to fixes to above mentioned files, when I decide what is the best way to go with those.

Alternatively we could do this as patch to OpenResty in `kong-build-tools`, but I felt like this module is good home for it.

This commit is related to:
https://github.com/Kong/kong/pull/8202
https://github.com/Kong/kong-build-tools/pull/427