### PR TITLE
fix(tls) remove depth param in ffi_set_upstream_ssl_verify

### DIFF
--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -640,7 +640,7 @@ failed:
 
 int
 ngx_http_lua_kong_ffi_set_upstream_ssl_verify(ngx_http_request_t *r,
-    int verify, int depth)
+    int verify)
 {
     ngx_http_lua_kong_ctx_t     *ctx;
 


### PR DESCRIPTION
I think it is an error in C declaration of ffi_set_upstream_ssl_verify.

There is a redundancy param depth, 
and in lua-resty code, the declaration is 

int ngx_http_lua_kong_ffi_set_upstream_ssl_verify(ngx_http_request_t *r,
        int verify);