### PR TITLE
chore(tls) use base.get_request instead of own code

### DIFF
--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -47,6 +47,7 @@ end
 
 local get_phase = ngx.get_phase
 local getfenv = getfenv
+local type = type
 local error = error
 local tostring = tostring
 local C = ffi.C

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -52,6 +52,7 @@ local C = ffi.C
 local ffi_string = ffi.string
 local get_string_buf = base.get_string_buf
 local size_ptr = base.get_size_ptr()
+local get_request = base.get_request
 
 
 local DEFAULT_CERT_CHAIN_SIZE = 10240
@@ -61,27 +62,6 @@ local NGX_AGAIN = ngx.AGAIN
 local NGX_DONE = ngx.DONE
 local NGX_DECLINED = ngx.DECLINED
 local NGX_ABORT = -6
-
-
-local get_request
-do
-    local ok, exdata = pcall(require, "thread.exdata")
-    if ok and exdata then
-        function get_request()
-            local r = exdata()
-            if r ~= nil then
-                return r
-            end
-        end
-
-    else
-        local getfenv = getfenv
-
-        function get_request()
-            return getfenv(0).__ngx_req
-        end
-    end
-end
 
 
 if ngx.config.subsystem == "http" then

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -48,6 +48,7 @@ end
 local get_phase = ngx.get_phase
 local getfenv = getfenv
 local error = error
+local tostring = tostring
 local C = ffi.C
 local ffi_string = ffi.string
 local get_string_buf = base.get_string_buf


### PR DESCRIPTION
We already have `get_request` in `resty.base` module,

I think we need not to keep own implement code in `tls.lua`. 