### PR TITLE
feat(*) a new static tag feature

### DIFF
--- a/config
+++ b/config
@@ -5,6 +5,7 @@ ngx_module_srcs=" \
                 $ngx_addon_dir/src/ngx_http_lua_kong_grpc.c \
                 $ngx_addon_dir/src/ngx_http_lua_kong_ssl.c \
                 $ngx_addon_dir/src/ngx_http_lua_kong_var.c \
+                $ngx_addon_dir/src/ngx_http_lua_kong_tag.c \
                 $ngx_addon_dir/src/ngx_http_lua_kong_module.c \
                 "
 

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -2,10 +2,6 @@ local ffi = require "ffi"
 local base = require "resty.core.base"
 
 
-local error = error
-local assert = assert
-
-
 local C = ffi.C
 local ffi_str = ffi.string
 local get_request = base.get_request

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -37,9 +37,13 @@ local function get()
         error("no request found")
     end
 
-    local tag = assert(ngx_lua_kong_get_static_tag(r))
+    local tag = ngx_lua_kong_get_static_tag(r)
 
-    return ffi_str(tag.data, tag.len)
+    if tag and tag.len > 0 then
+        return ffi_str(tag.data, tag.len)
+    end
+
+    return nil
 end
 
 

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -21,8 +21,11 @@ if subsystem == "http" then
 
 elseif subsystem == "stream" then
 
-    -- TODO: implement static tag in stream module
-    ngx_lua_kong_get_static_tag = function() end
+    ffi.cdef[[
+    ngx_str_t * ngx_stream_lua_kong_ffi_get_static_tag(ngx_stream_request_t *r);
+    ]]
+
+    ngx_lua_kong_get_static_tag = C.ngx_stream_lua_kong_ffi_get_static_tag
 
 end
 

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -22,7 +22,7 @@ if subsystem == "http" then
 elseif subsystem == "stream" then
 
     ffi.cdef[[
-    ngx_str_t * ngx_stream_lua_kong_ffi_get_static_tag(ngx_stream_request_t *r);
+    ngx_str_t * ngx_stream_lua_kong_ffi_get_static_tag(ngx_stream_lua_request_t *r);
     ]]
 
     ngx_lua_kong_get_static_tag = C.ngx_stream_lua_kong_ffi_get_static_tag

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -2,11 +2,7 @@ local ffi = require "ffi"
 local base = require "resty.core.base"
 
 
-local assert = assert
-
-
 local C = ffi.C
-local ffi_new = ffi.new
 local ffi_str = ffi.string
 local get_request = base.get_request
 local subsystem = ngx.config.subsystem
@@ -26,6 +22,7 @@ if subsystem == "http" then
 elseif subsystem == "stream" then
 
     -- TODO: implement static tag in stream module
+    ngx_lua_kong_get_static_tag = function() end
 
 end
 

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -2,6 +2,10 @@ local ffi = require "ffi"
 local base = require "resty.core.base"
 
 
+local error = error
+local assert = assert
+
+
 local C = ffi.C
 local ffi_str = ffi.string
 local get_request = base.get_request
@@ -33,9 +37,7 @@ local function get()
         error("no request found")
     end
 
-    local tag = ngx_lua_kong_get_static_tag(r)
-
-    --assert(tag ~= nil)
+    local tag = assert(ngx_lua_kong_get_static_tag(r))
 
     return ffi_str(tag.data, tag.len)
 end

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -1,0 +1,49 @@
+local ffi = require "ffi"
+local base = require "resty.core.base"
+
+
+local assert = assert
+
+
+local C = ffi.C
+local ffi_new = ffi.new
+local ffi_str = ffi.string
+local get_request = base.get_request
+local subsystem = ngx.config.subsystem
+
+
+local ngx_lua_kong_static_tag
+
+
+if subsystem == "http" then
+
+    ffi.cdef[[
+    ngx_str_t* ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r);
+    ]]
+
+    ngx_lua_kong_static_tag = C.ngx_http_lua_kong_ffi_static_tag
+
+elseif subsystem == "stream" then
+
+    -- TODO: implement static tag in stream module
+
+end
+
+local function get()
+    local r = get_request()
+
+    if not r then
+        error("no request found")
+    end
+
+    local tag = ngx_lua_kong_static_tag(r)
+
+    --assert(tag ~= nil)
+
+    return ffi_str(tag.data, tag.len)
+end
+
+
+return {
+    get = get,
+}

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -18,7 +18,7 @@ local ngx_lua_kong_static_tag
 if subsystem == "http" then
 
     ffi.cdef[[
-    ngx_str_t* ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r);
+    ngx_str_t * ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r);
     ]]
 
     ngx_lua_kong_static_tag = C.ngx_http_lua_kong_ffi_static_tag

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -12,16 +12,16 @@ local get_request = base.get_request
 local subsystem = ngx.config.subsystem
 
 
-local ngx_lua_kong_static_tag
+local ngx_lua_kong_get_static_tag
 
 
 if subsystem == "http" then
 
     ffi.cdef[[
-    ngx_str_t * ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r);
+    ngx_str_t * ngx_http_lua_kong_ffi_get_static_tag(ngx_http_request_t *r);
     ]]
 
-    ngx_lua_kong_static_tag = C.ngx_http_lua_kong_ffi_static_tag
+    ngx_lua_kong_get_static_tag = C.ngx_http_lua_kong_ffi_get_static_tag
 
 elseif subsystem == "stream" then
 
@@ -36,7 +36,7 @@ local function get()
         error("no request found")
     end
 
-    local tag = ngx_lua_kong_static_tag(r)
+    local tag = ngx_lua_kong_get_static_tag(r)
 
     --assert(tag ~= nil)
 

--- a/src/ngx_http_lua_kong_common.h
+++ b/src/ngx_http_lua_kong_common.h
@@ -36,6 +36,11 @@ typedef struct {
 } ngx_http_lua_kong_ctx_t;
 
 
+typedef struct {
+    ngx_str_t           tag;
+} ngx_http_lua_kong_loc_conf_t;
+
+
 #ifdef NGX_LUA_USE_ASSERT
 #include <assert.h>
 #   define ngx_http_lua_kong_assert(a)  assert(a)

--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -120,7 +120,7 @@ ngx_http_lua_kong_get_module_ctx(ngx_http_request_t *r)
 }
 
 
-static void*
+static void *
 ngx_http_lua_kong_create_loc_conf(ngx_conf_t* cf)
 {
     ngx_http_lua_kong_loc_conf_t* conf;

--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -123,7 +123,7 @@ ngx_http_lua_kong_get_module_ctx(ngx_http_request_t *r)
 static void *
 ngx_http_lua_kong_create_loc_conf(ngx_conf_t* cf)
 {
-    ngx_http_lua_kong_loc_conf_t* conf;
+    ngx_http_lua_kong_loc_conf_t *conf;
 
     conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_lua_kong_loc_conf_t));
     if (conf == NULL) {

--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -46,7 +46,7 @@ static ngx_command_t ngx_http_lua_kong_commands[] = {
       0,
       NULL },
 
-    { ngx_string("lua_kong_static_tag"),
+    { ngx_string("lua_kong_set_static_tag"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,
       NGX_HTTP_LOC_CONF_OFFSET,

--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -20,8 +20,8 @@
 
 
 static ngx_int_t ngx_http_lua_kong_init(ngx_conf_t *cf);
-
 static void* ngx_http_lua_kong_create_loc_conf(ngx_conf_t* cf);
+
 
 static ngx_http_module_t ngx_http_lua_kong_module_ctx = {
     NULL,                                    /* preconfiguration */
@@ -36,6 +36,7 @@ static ngx_http_module_t ngx_http_lua_kong_module_ctx = {
     ngx_http_lua_kong_create_loc_conf,       /* create location configuration */
     NULL                                     /* merge location configuration */
 };
+
 
 static ngx_command_t ngx_http_lua_kong_commands[] = {
 

--- a/src/ngx_http_lua_kong_module.c
+++ b/src/ngx_http_lua_kong_module.c
@@ -21,6 +21,7 @@
 
 static ngx_int_t ngx_http_lua_kong_init(ngx_conf_t *cf);
 
+static void* ngx_http_lua_kong_create_loc_conf(ngx_conf_t* cf);
 
 static ngx_http_module_t ngx_http_lua_kong_module_ctx = {
     NULL,                                    /* preconfiguration */
@@ -32,7 +33,7 @@ static ngx_http_module_t ngx_http_lua_kong_module_ctx = {
     NULL,                                    /* create server configuration */
     NULL,                                    /* merge server configuration */
 
-    NULL,                                    /* create location configuration */
+    ngx_http_lua_kong_create_loc_conf,       /* create location configuration */
     NULL                                     /* merge location configuration */
 };
 
@@ -43,6 +44,13 @@ static ngx_command_t ngx_http_lua_kong_commands[] = {
       ngx_http_lua_kong_load_var_index,
       0,
       0,
+      NULL },
+
+    { ngx_string("lua_kong_static_tag"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_lua_kong_loc_conf_t, tag),
       NULL },
 
     ngx_null_command
@@ -109,6 +117,20 @@ ngx_http_lua_kong_get_module_ctx(ngx_http_request_t *r)
     }
 
     return ctx;
+}
+
+
+static void*
+ngx_http_lua_kong_create_loc_conf(ngx_conf_t* cf)
+{
+    ngx_http_lua_kong_loc_conf_t* conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_lua_kong_loc_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    return conf;
 }
 
 

--- a/src/ngx_http_lua_kong_tag.c
+++ b/src/ngx_http_lua_kong_tag.c
@@ -18,7 +18,7 @@
 #include "ngx_http_lua_kong_common.h"
 
 
-ngx_str_t*
+ngx_str_t *
 ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r)
 {
     ngx_http_lua_kong_loc_conf_t* lcf;

--- a/src/ngx_http_lua_kong_tag.c
+++ b/src/ngx_http_lua_kong_tag.c
@@ -19,7 +19,7 @@
 
 
 ngx_str_t *
-ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r)
+ngx_http_lua_kong_ffi_get_static_tag(ngx_http_request_t *r)
 {
     ngx_http_lua_kong_loc_conf_t* lcf;
 

--- a/src/ngx_http_lua_kong_tag.c
+++ b/src/ngx_http_lua_kong_tag.c
@@ -21,7 +21,7 @@
 ngx_str_t *
 ngx_http_lua_kong_ffi_get_static_tag(ngx_http_request_t *r)
 {
-    ngx_http_lua_kong_loc_conf_t* lcf;
+    ngx_http_lua_kong_loc_conf_t *lcf;
 
     lcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_kong_module);
 

--- a/src/ngx_http_lua_kong_tag.c
+++ b/src/ngx_http_lua_kong_tag.c
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019-2022 Kong Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *    http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "ngx_http_lua_kong_common.h"
+
+
+ngx_str_t*
+ngx_http_lua_kong_ffi_static_tag(ngx_http_request_t *r)
+{
+    ngx_http_lua_kong_loc_conf_t* lcf;
+
+    lcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_kong_module);
+
+    return &lcf->tag;
+}
+
+

--- a/stream/src/ngx_stream_lua_kong_module.c
+++ b/stream/src/ngx_stream_lua_kong_module.c
@@ -22,6 +22,9 @@
 #include "ngx_stream_lua_kong_module.h"
 
 
+static void* ngx_stream_lua_kong_create_srv_conf(ngx_conf_t* cf);
+
+
 static ngx_stream_module_t ngx_stream_lua_kong_module_ctx = {
     NULL,                                  /* preconfiguration */
     NULL,                                  /* postconfiguration */
@@ -29,7 +32,7 @@ static ngx_stream_module_t ngx_stream_lua_kong_module_ctx = {
     NULL,                                  /* create main configuration */
     NULL,                                  /* init main configuration */
 
-    NULL,                                  /* create server configuration */
+    ngx_stream_lua_kong_create_srv_conf,   /* create server configuration */
     NULL                                   /* merge server configuration */
 };
 
@@ -48,6 +51,20 @@ ngx_module_t ngx_stream_lua_kong_module = {
     NULL,                              /* exit master */
     NGX_MODULE_V1_PADDING
 };
+
+
+static void *
+ngx_stream_lua_kong_create_srv_conf(ngx_conf_t* cf)
+{
+    ngx_stream_lua_kong_srv_conf_t *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_lua_kong_srv_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    return conf;
+}
 
 
 #if (NGX_STREAM_SSL)

--- a/stream/src/ngx_stream_lua_kong_module.c
+++ b/stream/src/ngx_stream_lua_kong_module.c
@@ -37,10 +37,23 @@ static ngx_stream_module_t ngx_stream_lua_kong_module_ctx = {
 };
 
 
+static ngx_command_t ngx_stream_lua_kong_commands[] = {
+
+    { ngx_string("lua_kong_set_static_tag"),
+      NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_lua_kong_srv_conf_t, tag),
+      NULL },
+
+    ngx_null_command
+};
+
+
 ngx_module_t ngx_stream_lua_kong_module = {
     NGX_MODULE_V1,
     &ngx_stream_lua_kong_module_ctx,   /* module context */
-    NULL,                              /* module directives */
+    ngx_stream_lua_kong_commands,      /* module directives */
     NGX_STREAM_MODULE,                 /* module type */
     NULL,                              /* init master */
     NULL,                              /* init module */
@@ -64,6 +77,17 @@ ngx_stream_lua_kong_create_srv_conf(ngx_conf_t* cf)
     }
 
     return conf;
+}
+
+
+ngx_str_t *
+ngx_stream_lua_kong_ffi_get_static_tag(ngx_stream_session_t *s)
+{
+    ngx_stream_lua_kong_srv_conf_t *scf;
+
+    scf = ngx_stream_get_module_srv_conf(s, ngx_stream_lua_kong_module);
+
+    return &scf->tag;
 }
 
 

--- a/stream/src/ngx_stream_lua_kong_module.c
+++ b/stream/src/ngx_stream_lua_kong_module.c
@@ -81,11 +81,12 @@ ngx_stream_lua_kong_create_srv_conf(ngx_conf_t* cf)
 
 
 ngx_str_t *
-ngx_stream_lua_kong_ffi_get_static_tag(ngx_stream_session_t *s)
+ngx_stream_lua_kong_ffi_get_static_tag(ngx_stream_lua_request_t *r)
 {
     ngx_stream_lua_kong_srv_conf_t *scf;
 
-    scf = ngx_stream_get_module_srv_conf(s, ngx_stream_lua_kong_module);
+    scf = ngx_stream_get_module_srv_conf(
+            r->session, ngx_stream_lua_kong_module);
 
     return &scf->tag;
 }

--- a/stream/src/ngx_stream_lua_kong_module.h
+++ b/stream/src/ngx_stream_lua_kong_module.h
@@ -12,6 +12,11 @@ typedef struct {
 } ngx_stream_lua_kong_ctx_t;
 
 
+typedef struct {
+    ngx_str_t               tag;
+} ngx_stream_lua_kong_srv_conf_t;
+
+
 #if (NGX_STREAM_SSL)
 
 ngx_uint_t

--- a/t/007-static-tag.t
+++ b/t/007-static-tag.t
@@ -62,3 +62,37 @@ value:nil
 
 
 
+=== TEST 3: set tag for internal location block
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- config
+    location = /test {
+        lua_kong_set_static_tag "test-tag";
+        content_by_lua_block {
+            local tag = require "resty.kong.tag"
+            ngx.say("value:", tag.get())
+
+            local res = ngx.location.capture("/inner")
+            ngx.say(res.body)
+        }
+    }
+    location = /inner {
+        internal;
+        lua_kong_set_static_tag "inner-tag";
+        content_by_lua_block {
+            local tag = require "resty.kong.tag"
+            ngx.print("value:", tag.get())
+        }
+    }
+--- request
+GET /test
+--- response_body
+value:test-tag
+value:inner-tag
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+

--- a/t/007-static-tag.t
+++ b/t/007-static-tag.t
@@ -1,0 +1,64 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+# modified from https://github.com/openresty/lua-nginx-module/blob/master/t/045-ngx-var.t
+# with index always turned on
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 5);
+
+#no_diff();
+#no_long_string();
+#master_on();
+#workers(2);
+run_tests();
+
+__DATA__
+
+=== TEST 1: sanity: directive works well
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- config
+    location = /test {
+        lua_kong_static_tag "it works";
+        content_by_lua_block {
+            local tag = require "resty.kong.tag"
+            ngx.say(tag.get())
+        }
+    }
+--- request
+GET /test
+--- response_body
+it works
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+
+=== TEST 2: default tag is empty string
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- config
+    location = /test {
+        content_by_lua_block {
+            local tag = require "resty.kong.tag"
+            ngx.say("value:", tag.get())
+        }
+    }
+--- request
+GET /test
+--- response_body
+value:
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+

--- a/t/007-static-tag.t
+++ b/t/007-static-tag.t
@@ -96,3 +96,29 @@ value:inner-tag
 
 
 
+=== TEST 4: set tag for nested location block
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- config
+    location /test {
+        lua_kong_set_static_tag "test-tag";
+
+        location /test/nested {
+            lua_kong_set_static_tag "nested-tag";
+            content_by_lua_block {
+                local tag = require "resty.kong.tag"
+                ngx.say("value:", tag.get())
+            }
+        }
+    }
+--- request
+GET /test/nested
+--- response_body
+value:nested-tag
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+

--- a/t/007-static-tag.t
+++ b/t/007-static-tag.t
@@ -41,7 +41,7 @@ it works
 
 
 
-=== TEST 2: default tag is empty string
+=== TEST 2: default tag is nil
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 --- config
@@ -54,7 +54,7 @@ it works
 --- request
 GET /test
 --- response_body
-value:
+value:nil
 --- no_error_log
 [error]
 [crit]

--- a/t/007-static-tag.t
+++ b/t/007-static-tag.t
@@ -24,7 +24,7 @@ __DATA__
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 --- config
     location = /test {
-        lua_kong_static_tag "it works";
+        lua_kong_set_static_tag "it works";
         content_by_lua_block {
             local tag = require "resty.kong.tag"
             ngx.say(tag.get())

--- a/t/stream/002-static-tag.t
+++ b/t/stream/002-static-tag.t
@@ -1,0 +1,53 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua::Stream;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+log_level('warn');
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 5);
+
+#no_diff();
+#no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: sanity: directive works well
+--- stream_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- stream_server_config
+    lua_kong_set_static_tag "it works";
+    content_by_lua_block {
+        local tag = require "resty.kong.tag"
+        ngx.say(tag.get())
+    }
+--- response_body
+it works
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+
+=== TEST 2: default tag is nil
+--- stream_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- stream_server_config
+    content_by_lua_block {
+        local tag = require "resty.kong.tag"
+        ngx.say("value:", tag.get())
+    }
+--- response_body
+value:nil
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+


### PR DESCRIPTION
I noticed that we use some vars as semantic tag in nginx config file, 
such as `$kong_proxy_mode`.

It works well but I don't think it is the proper usage of nginx vars.

So I add a new directive `lua_kong_set_static_tag`, which will store the static string in the module's loc_conf_t,
and we can access the value very fast without the cost of var hash searching.

I also did a simple performance test, get the value for 5000*1000 times by `ngx.var` and `tag.get`,
the result is:

0.21599984169006
0.005000114440918

You can see `tag.get` is extremely faster  than `ngx.var`.

If you have interest in this feature I will improve the code, please give me some suggestions. 





