### PR TITLE
feat(tls) add new API `tls.set_client_ca_list(ca_list)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This function returns `true` when the call is successful. Otherwise it returns
 
 resty.kong.tls.set\_client\_ca\_list
 -------------------------------------------
-**syntax:** *succ, err = resty.kong.tls.set\_client\_ca\_list(name_list)*
+**syntax:** *succ, err = resty.kong.tls.set\_client\_ca\_list(ca_list)*
 
 **context:** *ssl_certificate_by_lua&#42;*
 
@@ -178,8 +178,8 @@ Certificate Request Message of downstram TLS handshake.
 The downstream client then can use this DN information to filter certificates,
 and chooses an appropriate certificate issued by a CA in the list.
 
-`name_list` is of type `STACK(X509_NAME) *` which a raw C pointer returned by
-the OpenSSL API.
+`name_list` is of type `STACK_OF(X509) *` which can be created by using the API
+of `resty.openssl.x509.chain`
 
 This function returns `true` when the call is successful. Otherwise it returns
 `nil` and a string describing the error.

--- a/README.md
+++ b/README.md
@@ -178,8 +178,39 @@ Certificate Request Message of downstram TLS handshake.
 The downstream client then can use this DN information to filter certificates,
 and chooses an appropriate certificate issued by a CA in the list.
 
-`name_list` is of type `STACK_OF(X509) *` which can be created by using the API
-of `resty.openssl.x509.chain`
+`ca_list` is of type `STACK_OF(X509) *` which can be created by using the API
+of `resty.openssl.x509.chain` as follows:
+
+```lua
+local tls_lib = require "resty.kong.tls"
+local x509_lib = require "resty.openssl.x509"
+local chain_lib = require "resty.openssl.x509.chain"
+
+local suc, err
+local chain = chain_lib.new()
+-- err check
+local x509, err = x509_lib.new(pem_cert, "PEM")
+-- err check
+suc, err = chain:add(x509)
+-- err check
+
+-- `chain.ctx` is the raw data of the chain, i.e. `STACK_OF(X509) *`
+suc, err = tls_lib.set_client_ca_list(chain.ctx)
+-- err check
+```
+
+Or by using `ngx.ssl` as follows:
+
+```lua
+local ssl = require "ngx.ssl"
+
+local chain, err = ssl.parse_pem_cert(pem_cert_chain)
+-- note the `chain` returned by `ssl.parse_pem_cert` is already a raw `STACK_OF(X509) *`
+-- err check
+
+suc, err = tls_lib.set_client_ca_list(chain)
+-- err check
+```
 
 This function returns `true` when the call is successful. Otherwise it returns
 `nil` and a string describing the error.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Table of Contents
 * [Methods](#methods)
     * [resty.kong.tls.request\_client\_certificate](#restykongtlsrequest_client_certificate)
     * [resty.kong.tls.disable\_session\_reuse](#restykongtlsdisable_session_reuse)
+    * [resty.kong.tls.set\_client\_ca\_list](#restykongtlsset_client_ca_list)
     * [resty.kong.tls.get\_full\_client\_certificate\_chain](#restykongtlsget_full_client_certificate_chain)
     * [resty.kong.tls.set\_upstream\_cert\_and\_key](#restykongtlsset_upstream_cert_and_key)
     * [resty.kong.tls.set\_upstream\_ssl\_trusted\_store](#restykongtlsset_upstream_ssl_trusted_store)
@@ -157,6 +158,28 @@ resty.kong.tls.disable\_session\_reuse
 
 Prevents the TLS session for the current connection from being reused by
 disabling session ticket and session ID for the current TLS connection.
+
+This function returns `true` when the call is successful. Otherwise it returns
+`nil` and a string describing the error.
+
+[Back to TOC](#table-of-contents)
+
+resty.kong.tls.set\_client\_ca\_list
+-------------------------------------------
+**syntax:** *succ, err = resty.kong.tls.set\_client\_ca\_list(name_list)*
+
+**context:** *ssl_certificate_by_lua&#42;*
+
+**subsystems:** *http*
+
+Set the CA DN list to the underlying SSL structure, which will be sent in the
+Certificate Request Message of downstram TLS handshake.
+
+The downstream client then can use this DN information to filter certificates,
+and chooses an appropriate certificate issued by a CA in the list.
+
+`name_list` is of type `STACK(X509_NAME) *` which a raw C pointer returned by
+the OpenSSL API.
 
 This function returns `true` when the call is successful. Otherwise it returns
 `nil` and a string describing the error.

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -27,6 +27,9 @@ if ngx.config.subsystem == "http" then
     int ngx_http_lua_kong_ffi_get_full_client_certificate_chain(
         ngx_http_request_t *r, char *buf, size_t *buf_len);
     const char *ngx_http_lua_kong_ffi_disable_session_reuse(ngx_http_request_t *r);
+    // STACK_OF(X509_NAME)
+    const char *ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
+        OPENSSL_STACK *name_list);
     int ngx_http_lua_kong_ffi_set_upstream_client_cert_and_key(ngx_http_request_t *r,
         void *_chain, void *_key);
     int ngx_http_lua_kong_ffi_set_upstream_ssl_trusted_store(ngx_http_request_t *r,
@@ -91,6 +94,22 @@ if ngx.config.subsystem == "http" then
         local r = get_request()
 
         local errmsg = C.ngx_http_lua_kong_ffi_disable_session_reuse(r)
+        if errmsg == nil then
+            return true
+        end
+
+        return nil, ffi_string(errmsg)
+    end
+
+
+    function _M.set_client_ca_list(name_list)
+        if get_phase() ~= 'ssl_cert' then
+            error("API disabled in the current context")
+        end
+
+        local r = get_request()
+
+        local errmsg = C.ngx_http_lua_kong_ffi_set_client_ca_list(r, name_list)
         if errmsg == nil then
             return true
         end

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -29,7 +29,7 @@ if ngx.config.subsystem == "http" then
     const char *ngx_http_lua_kong_ffi_disable_session_reuse(ngx_http_request_t *r);
     // STACK_OF(X509_NAME)
     const char *ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
-        OPENSSL_STACK *name_list);
+        void *name_list);
     int ngx_http_lua_kong_ffi_set_upstream_client_cert_and_key(ngx_http_request_t *r,
         void *_chain, void *_key);
     int ngx_http_lua_kong_ffi_set_upstream_ssl_trusted_store(ngx_http_request_t *r,

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -27,9 +27,9 @@ if ngx.config.subsystem == "http" then
     int ngx_http_lua_kong_ffi_get_full_client_certificate_chain(
         ngx_http_request_t *r, char *buf, size_t *buf_len);
     const char *ngx_http_lua_kong_ffi_disable_session_reuse(ngx_http_request_t *r);
-    // STACK_OF(X509_NAME)
+    // STACK_OF(X509)
     const char *ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
-        void *name_list);
+        void *ca_list);
     int ngx_http_lua_kong_ffi_set_upstream_client_cert_and_key(ngx_http_request_t *r,
         void *_chain, void *_key);
     int ngx_http_lua_kong_ffi_set_upstream_ssl_trusted_store(ngx_http_request_t *r,
@@ -102,14 +102,16 @@ if ngx.config.subsystem == "http" then
     end
 
 
-    function _M.set_client_ca_list(name_list)
+    function _M.set_client_ca_list(ca_list)
         if get_phase() ~= 'ssl_cert' then
             error("API disabled in the current context")
         end
 
         local r = get_request()
+        -- no need to check if r is nil as phase check above
+        -- already ensured it
 
-        local errmsg = C.ngx_http_lua_kong_ffi_set_client_ca_list(r, name_list)
+        local errmsg = C.ngx_http_lua_kong_ffi_set_client_ca_list(r, ca_list)
         if errmsg == nil then
             return true
         end

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -27,7 +27,6 @@ if ngx.config.subsystem == "http" then
     int ngx_http_lua_kong_ffi_get_full_client_certificate_chain(
         ngx_http_request_t *r, char *buf, size_t *buf_len);
     const char *ngx_http_lua_kong_ffi_disable_session_reuse(ngx_http_request_t *r);
-    // STACK_OF(X509)
     const char *ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
         void *ca_list);
     int ngx_http_lua_kong_ffi_set_upstream_client_cert_and_key(ngx_http_request_t *r,

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -108,8 +108,9 @@ if ngx.config.subsystem == "http" then
         end
 
         local r = get_request()
-        -- no need to check if r is nil as phase check above
-        -- already ensured it
+        if not r then
+            error("no request found")
+        end
 
         local errmsg = C.ngx_http_lua_kong_ffi_set_client_ca_list(r, ca_list)
         if errmsg == nil then

--- a/src/ngx_http_lua_kong_ssl.c
+++ b/src/ngx_http_lua_kong_ssl.c
@@ -206,7 +206,6 @@ ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
 
     sc = c->ssl->connection;
 
-
     for (i = 0; i < sk_X509_num(ca_list); i++) {
         ca = sk_X509_value(ca_list, i);
 
@@ -219,7 +218,7 @@ ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
     return NULL;
 
 #else
-    return "TLS support is not enabled in Nginx build"
+    return "TLS support is not enabled in Nginx build";
 #endif
 }
 

--- a/src/ngx_http_lua_kong_ssl.c
+++ b/src/ngx_http_lua_kong_ssl.c
@@ -179,6 +179,42 @@ ngx_http_lua_kong_ffi_request_client_certificate(ngx_http_request_t *r)
 }
 
 
+/*
+ * Set the CA DN list to the underlying SSL structure, which will be sent in the
+ * Certificate Request Message of downstram TLS handshake.
+ *
+ * The downstream client can use this DN information to filter certificates,
+ * and chooses an appropriate certificate issued by a CA in the list.
+ *
+ * on success, NULL is returned, otherwise a static string indicating the
+ * failure reason is returned.
+ */
+
+const char *
+ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
+                                         STACK_OF(X509_NAME) *name_list)
+{
+#if (NGX_SSL)
+    ngx_connection_t    *c = r->connection;
+    ngx_ssl_conn_t      *sc;
+
+    if (c->ssl == NULL) {
+        return "server does not have TLS enabled";
+    }
+
+    sc = c->ssl->connection;
+
+
+    SSL_set_client_CA_list(sc, name_list);
+
+    return NULL;
+
+#else
+    return "TLS support is not enabled in Nginx build"
+#endif
+}
+
+
 int
 ngx_http_lua_kong_ffi_get_full_client_certificate_chain(ngx_http_request_t *r,
     char *buf, size_t *buf_len)

--- a/src/ngx_http_lua_kong_ssl.c
+++ b/src/ngx_http_lua_kong_ssl.c
@@ -192,7 +192,7 @@ ngx_http_lua_kong_ffi_request_client_certificate(ngx_http_request_t *r)
 
 const char *
 ngx_http_lua_kong_ffi_set_client_ca_list(ngx_http_request_t *r,
-                                         STACK_OF(X509) *ca_list)
+                                         const STACK_OF(X509) *ca_list)
 {
 #if (NGX_SSL)
     ngx_connection_t    *c = r->connection;

--- a/t/001-tls.t
+++ b/t/001-tls.t
@@ -619,11 +619,11 @@ nil, connection is not TLS or TLS support for Nginx not enabled
                 ngx.log(ngx.ERR, "unable to popen openssl: ", err)
                 return ngx.exit(ngx.ERROR)
             end
-	    ngx.sleep(2)
+            ngx.sleep(2)
             assert(handle:write("bad request\n"))
             handle:close()
 
-            handle = io.popen("grep -A 2 'Acceptable client certificate CA names' /tmp/output.txt")
+            handle = io.popen("grep '^Acceptable client certificate CA names$\\|^C = US,' /tmp/output.txt")
             if not handle then
                 ngx.log(ngx.ERR, "unable to popen grep: ", err)
                 return ngx.exit(ngx.ERROR)
@@ -696,11 +696,11 @@ ssl cert by lua complete!
                 ngx.log(ngx.ERR, "unable to popen openssl: ", err)
                 return ngx.exit(ngx.ERROR)
             end
-	    ngx.sleep(2)
+            ngx.sleep(2)
             assert(handle:write("bad request\n"))
             handle:close()
 
-            handle = io.popen("grep 'No client certificate CA names sent' /tmp/output.txt")
+            handle = io.popen("grep '^No client certificate CA names sent$' /tmp/output.txt")
             if not handle then
                 ngx.log(ngx.ERR, "unable to popen grep: ", err)
                 return ngx.exit(ngx.ERROR)

--- a/t/001-tls.t
+++ b/t/001-tls.t
@@ -5,7 +5,7 @@ use Cwd qw(cwd);
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 5 + 1);
+plan tests => repeat_each() * (blocks() * 6 - 1);
 
 my $pwd = cwd();
 
@@ -515,6 +515,209 @@ GET /t
 nil, connection is not TLS or TLS support for Nginx not enabled
 
 --- error_log
+
+--- no_error_log
+[error]
+[alert]
+[warn]
+[crit]
+
+
+
+=== TEST 7: calling set_client_ca_list, ca dn list is sent
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   example.com;
+        ssl_certificate_by_lua_block {
+            print("ssl cert by lua is running!")
+
+            local tls_lib = require "resty.kong.tls"
+            local x509_lib = require "resty.openssl.x509"
+            local chain_lib = require "resty.openssl.x509.chain"
+
+            local subcafile, cafile, chain, subca, ca, suc, err
+
+            suc, err = tls_lib.request_client_certificate()
+            if err then
+                ngx.log(ngx.ERR, "unable to request client certificate: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            subcafile, err = io.open("t/cert/intermediate.crt", "r")
+            if err then
+                ngx.log(ngx.ERR, "unable to open file t/cert/intermediate.crt: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            cafile, err = io.open("t/cert/ca.crt", "r")
+            if err then
+                ngx.log(ngx.ERR, "unable to open file t/cert/ca.crt: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            chain, err = chain_lib.new()
+            if err then
+                ngx.log(ngx.ERR, "unable to new chain: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            subca, err = x509_lib.new(subcafile:read("*a"), "PEM")
+            if err then
+                ngx.log(ngx.ERR, "unable to read and parse the subca cert: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            ca, err = x509_lib.new(cafile:read("*a"), "PEM")
+            if err then
+                ngx.log(ngx.ERR, "unable to read and parse the ca cert: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            suc, err = chain:add(subca)
+            if err then
+                ngx.log(ngx.ERR, "unable to add the subca cert to the chain: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            suc, err = chain:add(ca)
+            if err then
+                ngx.log(ngx.ERR, "unable to add the ca cert to the chain: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            suc, err = tls_lib.set_client_ca_list(chain.ctx)
+            if err then
+                ngx.log(ngx.ERR, "unable to set client ca list: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            print("ssl cert by lua complete!")
+        }
+        ssl_certificate ../../cert/example.com.crt;
+        ssl_certificate_key ../../cert/example.com.key;
+        ssl_session_tickets off;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {
+                ngx.say("impossibe to reach here")
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+
+    location /t {
+        content_by_lua_block {
+            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt", "w")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen openssl: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+	    ngx.sleep(2)
+            assert(handle:write("bad request\n"))
+            handle:close()
+
+            handle = io.popen("grep -A 2 'Acceptable client certificate CA names' /tmp/output.txt")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen grep: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+            ngx.print(handle:read("*a"))
+            handle:close()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+Acceptable client certificate CA names
+C = US, ST = California, O = Kong Testing, CN = Kong Testing Intermidiate CA
+C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
+
+--- error_log
+ssl cert by lua is running!
+ssl cert by lua complete!
+
+--- no_error_log
+[error]
+[alert]
+[warn]
+[crit]
+
+
+
+=== TEST 8: without calling set_client_ca_list, ca dn list isn't sent
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   example.com;
+        ssl_certificate_by_lua_block {
+            print("ssl cert by lua is running!")
+
+            local tls_lib = require "resty.kong.tls"
+            local suc, err
+
+            suc, err = tls_lib.request_client_certificate()
+            if err then
+                ngx.log(ngx.ERR, "unable to request client certificate: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            print("ssl cert by lua complete!")
+        }
+        ssl_certificate ../../cert/example.com.crt;
+        ssl_certificate_key ../../cert/example.com.key;
+        ssl_session_tickets off;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {
+                ngx.say("impossibe to reach here")
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+
+    location /t {
+        content_by_lua_block {
+            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt", "w")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen openssl: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+	    ngx.sleep(2)
+            assert(handle:write("bad request\n"))
+            handle:close()
+
+            handle = io.popen("grep 'No client certificate CA names sent' /tmp/output.txt")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen grep: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+            ngx.print(handle:read("*a"))
+            handle:close()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+No client certificate CA names sent
+
+--- error_log
+ssl cert by lua is running!
+ssl cert by lua complete!
 
 --- no_error_log
 [error]

--- a/t/001-tls.t
+++ b/t/001-tls.t
@@ -5,7 +5,7 @@ use Cwd qw(cwd);
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 6 - 1);
+plan tests => repeat_each() * (blocks() * 6 + 3);
 
 my $pwd = cwd();
 
@@ -524,7 +524,7 @@ nil, connection is not TLS or TLS support for Nginx not enabled
 
 
 
-=== TEST 7: calling set_client_ca_list, ca dn list is sent
+=== TEST 7: calling set_client_ca_list, ca dn list is sent (using `resty.openssl.x509.chain`)
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
@@ -539,6 +539,8 @@ nil, connection is not TLS or TLS support for Nginx not enabled
             local chain_lib = require "resty.openssl.x509.chain"
 
             local subcafile, cafile, chain, subca, ca, suc, err
+            local ca_path = "t/cert/ca.crt"
+            local subca_path = "t/cert/intermediate.crt"
 
             suc, err = tls_lib.request_client_certificate()
             if err then
@@ -546,15 +548,15 @@ nil, connection is not TLS or TLS support for Nginx not enabled
                 return ngx.exit(ngx.ERROR)
             end
 
-            subcafile, err = io.open("t/cert/intermediate.crt", "r")
+            subcafile, err = io.open(subca_path, "r")
             if err then
-                ngx.log(ngx.ERR, "unable to open file t/cert/intermediate.crt: ", err)
+                ngx.log(ngx.ERR, "unable to open file " .. subca_path .. ": ", err)
                 return ngx.exit(ngx.ERROR)
             end
 
-            cafile, err = io.open("t/cert/ca.crt", "r")
+            cafile, err = io.open(ca_path, "r")
             if err then
-                ngx.log(ngx.ERR, "unable to open file t/cert/ca.crt: ", err)
+                ngx.log(ngx.ERR, "unable to open file " .. ca_path .. ": ", err)
                 return ngx.exit(ngx.ERROR)
             end
 
@@ -569,12 +571,14 @@ nil, connection is not TLS or TLS support for Nginx not enabled
                 ngx.log(ngx.ERR, "unable to read and parse the subca cert: ", err)
                 return ngx.exit(ngx.ERROR)
             end
+            subcafile:close()
 
             ca, err = x509_lib.new(cafile:read("*a"), "PEM")
             if err then
                 ngx.log(ngx.ERR, "unable to read and parse the ca cert: ", err)
                 return ngx.exit(ngx.ERROR)
             end
+            cafile:close()
 
             suc, err = chain:add(subca)
             if err then
@@ -614,13 +618,12 @@ nil, connection is not TLS or TLS support for Nginx not enabled
 
     location /t {
         content_by_lua_block {
-            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt", "w")
+            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt")
             if not handle then
                 ngx.log(ngx.ERR, "unable to popen openssl: ", err)
                 return ngx.exit(ngx.ERROR)
             end
             ngx.sleep(2)
-            assert(handle:write("bad request\n"))
             handle:close()
 
             handle = io.popen("grep '^Acceptable client certificate CA names$\\|^C = US,' /tmp/output.txt")
@@ -652,7 +655,111 @@ ssl cert by lua complete!
 
 
 
-=== TEST 8: without calling set_client_ca_list, ca dn list isn't sent
+=== TEST 8: calling set_client_ca_list, ca dn list is sent (using `ngx.ssl.parse_pem_cert`)
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   example.com;
+        ssl_certificate_by_lua_block {
+            print("ssl cert by lua is running!")
+
+            local tls_lib = require "resty.kong.tls"
+            local ssl_lib = require "ngx.ssl"
+
+            local cafile, cadata, chain, suc, err
+            local ca_path = "t/cert/ca.crt"
+
+            suc, err = tls_lib.request_client_certificate()
+            if err then
+                ngx.log(ngx.ERR, "unable to request client certificate: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            cafile, err = io.open(ca_path, "r")
+            if err then
+                ngx.log(ngx.ERR, "unable to open file " .. ca_path .. ": ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            cadata = cafile:read("*a")
+            if not cadata then
+                ngx.log(ngx.ERR, "unable to read file " .. ca_path)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            cafile:close()
+
+            chain, err = ssl_lib.parse_pem_cert(cadata)
+            if err then
+                ngx.log(ngx.ERR, "unable to parse the pem ca cert: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            suc, err = tls_lib.set_client_ca_list(chain)
+            if err then
+                ngx.log(ngx.ERR, "unable to set client ca list: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            print("ssl cert by lua complete!")
+        }
+        ssl_certificate ../../cert/example.com.crt;
+        ssl_certificate_key ../../cert/example.com.key;
+        ssl_session_tickets off;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {
+                ngx.say("impossibe to reach here")
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+
+    location /t {
+        content_by_lua_block {
+            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen openssl: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+            ngx.sleep(2)
+            handle:close()
+
+            handle = io.popen("grep '^Acceptable client certificate CA names$\\|^C = US,' /tmp/output.txt")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen grep: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+            ngx.print(handle:read("*a"))
+            handle:close()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+Acceptable client certificate CA names
+C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
+
+--- error_log
+ssl cert by lua is running!
+ssl cert by lua complete!
+
+--- no_error_log
+[error]
+[alert]
+[warn]
+[crit]
+
+
+
+=== TEST 9: without calling set_client_ca_list, ca dn list isn't sent
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
@@ -691,13 +798,100 @@ ssl cert by lua complete!
 
     location /t {
         content_by_lua_block {
-            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt", "w")
+            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt")
             if not handle then
                 ngx.log(ngx.ERR, "unable to popen openssl: ", err)
                 return ngx.exit(ngx.ERROR)
             end
             ngx.sleep(2)
-            assert(handle:write("bad request\n"))
+            handle:close()
+
+            handle = io.popen("grep '^No client certificate CA names sent$' /tmp/output.txt")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen grep: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+            ngx.print(handle:read("*a"))
+            handle:close()
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+No client certificate CA names sent
+
+--- error_log
+ssl cert by lua is running!
+ssl cert by lua complete!
+
+--- no_error_log
+[error]
+[alert]
+[warn]
+[crit]
+
+
+
+=== TEST 10: calling set_client_ca_list with an empty chain, no real effect, ca dn list isn't sent
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   example.com;
+        ssl_certificate_by_lua_block {
+            print("ssl cert by lua is running!")
+
+            local tls_lib = require "resty.kong.tls"
+            local chain_lib = require "resty.openssl.x509.chain"
+
+            local chain, suc, err
+
+            suc, err = tls_lib.request_client_certificate()
+            if err then
+                ngx.log(ngx.ERR, "unable to request client certificate: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            chain, err = chain_lib.new()
+            if err then
+                ngx.log(ngx.ERR, "unable to new chain: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            suc, err = tls_lib.set_client_ca_list(chain.ctx)
+            if err then
+                ngx.log(ngx.ERR, "unable to set client ca list: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+
+            print("ssl cert by lua complete!")
+        }
+        ssl_certificate ../../cert/example.com.crt;
+        ssl_certificate_key ../../cert/example.com.key;
+        ssl_session_tickets off;
+
+        server_tokens off;
+        location /foo {
+            default_type 'text/plain';
+            content_by_lua_block {
+                ngx.say("impossibe to reach here")
+            }
+            more_clear_headers Date;
+        }
+    }
+--- config
+    server_tokens off;
+
+    location /t {
+        content_by_lua_block {
+            local handle = io.popen("openssl s_client -unix $TEST_NGINX_HTML_DIR/nginx.sock > /tmp/output.txt")
+            if not handle then
+                ngx.log(ngx.ERR, "unable to popen openssl: ", err)
+                return ngx.exit(ngx.ERROR)
+            end
+            ngx.sleep(2)
             handle:close()
 
             handle = io.popen("grep '^No client certificate CA names sent$' /tmp/output.txt")


### PR DESCRIPTION
This API adds the CA DN list to the underlying SSL structure, which will be sent in the Certificate Request message.

The client then can use this DN information to filter the certs and chooses an appropriate cert issued by a CA in the list.

FTI-4430