### PR TITLE
chore(*): add check of get_request() and the missing ';'

### DIFF
--- a/lualib/resty/kong/grpc.lua
+++ b/lualib/resty/kong/grpc.lua
@@ -60,6 +60,9 @@ do
         end
 
         local r = get_request()
+        if not r then
+            error("no request found")
+        end
 
         local ret = C.ngx_http_lua_kong_ffi_set_grpc_authority(r, authority,
                                                                #authority)

--- a/lualib/resty/kong/grpc.lua
+++ b/lualib/resty/kong/grpc.lua
@@ -30,13 +30,23 @@ int ngx_http_lua_kong_ffi_set_grpc_authority(ngx_http_request_t *r,
 local error = error
 local type = type
 local C = ffi.C
-local get_request = base.get_request
+local orig_get_request = base.get_request
 local get_phase = ngx.get_phase
 
 
 local NGX_OK = ngx.OK
 local NGX_ERROR = ngx.ERROR
 
+
+local function get_request()
+    local r = orig_get_request()
+
+    if not r then
+        error("no request found")
+    end
+
+    return r
+end
 
 do
     local ALLOWED_PHASES = {
@@ -60,9 +70,6 @@ do
         end
 
         local r = get_request()
-        if not r then
-            error("no request found")
-        end
 
         local ret = C.ngx_http_lua_kong_ffi_set_grpc_authority(r, authority,
                                                                #authority)

--- a/lualib/resty/kong/tag.lua
+++ b/lualib/resty/kong/tag.lua
@@ -4,7 +4,7 @@ local base = require "resty.core.base"
 
 local C = ffi.C
 local ffi_str = ffi.string
-local get_request = base.get_request
+local orig_get_request = base.get_request
 local subsystem = ngx.config.subsystem
 
 
@@ -29,12 +29,18 @@ elseif subsystem == "stream" then
 
 end
 
-local function get()
-    local r = get_request()
+local function get_request()
+    local r = orig_get_request()
 
     if not r then
         error("no request found")
     end
+
+    return r
+end
+
+local function get()
+    local r = get_request()
 
     local tag = ngx_lua_kong_get_static_tag(r)
 

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -71,8 +71,9 @@ if ngx.config.subsystem == "http" then
         end
 
         local r = get_request()
-        -- no need to check if r is nil as phase check above
-        -- already ensured it
+        if not r then
+            error("no request found")
+        end
 
         local errmsg = C.ngx_http_lua_kong_ffi_request_client_certificate(r)
         if errmsg == nil then
@@ -89,6 +90,9 @@ if ngx.config.subsystem == "http" then
         end
 
         local r = get_request()
+        if not r then
+            error("no request found")
+        end
 
         local errmsg = C.ngx_http_lua_kong_ffi_disable_session_reuse(r)
         if errmsg == nil then
@@ -114,6 +118,9 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
+            if not r then
+                error("no request found")
+            end
 
             size_ptr[0] = DEFAULT_CERT_CHAIN_SIZE
 
@@ -166,6 +173,9 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
+            if not r then
+                error("no request found")
+            end
 
             local ret = C.ngx_http_lua_kong_ffi_set_upstream_client_cert_and_key(
                 r, chain, key)
@@ -194,6 +204,9 @@ if ngx.config.subsystem == "http" then
               end
 
               local r = get_request()
+              if not r then
+                  error("no request found")
+              end
 
               local ret = C.ngx_http_lua_kong_ffi_set_upstream_ssl_trusted_store(
                   r, store.ctx)
@@ -219,6 +232,9 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
+            if not r then
+                error("no request found")
+            end
 
             local ret = C.ngx_http_lua_kong_ffi_set_upstream_ssl_verify(
                 r, verify)
@@ -247,6 +263,9 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
+            if not r then
+                error("no request found")
+            end
 
             local ret = C.ngx_http_lua_kong_ffi_set_upstream_ssl_verify_depth(
                 r, depth)
@@ -275,6 +294,9 @@ else -- stream
             end
 
             local r = get_request()
+            if not r then
+                error("no request found")
+            end
 
             local ret = C.ngx_stream_lua_kong_ffi_proxy_ssl_disable(r)
             if ret == NGX_OK then

--- a/lualib/resty/kong/tls.lua
+++ b/lualib/resty/kong/tls.lua
@@ -53,7 +53,7 @@ local C = ffi.C
 local ffi_string = ffi.string
 local get_string_buf = base.get_string_buf
 local size_ptr = base.get_size_ptr()
-local get_request = base.get_request
+local orig_get_request = base.get_request
 
 
 local DEFAULT_CERT_CHAIN_SIZE = 10240
@@ -64,6 +64,16 @@ local NGX_DECLINED = ngx.DECLINED
 local NGX_ABORT = -6
 
 
+local function get_request()
+    local r = orig_get_request()
+
+    if not r then
+        error("no request found")
+    end
+
+    return r
+end
+
 if ngx.config.subsystem == "http" then
     function _M.request_client_certificate(no_session_reuse)
         if get_phase() ~= 'ssl_cert' then
@@ -71,9 +81,6 @@ if ngx.config.subsystem == "http" then
         end
 
         local r = get_request()
-        if not r then
-            error("no request found")
-        end
 
         local errmsg = C.ngx_http_lua_kong_ffi_request_client_certificate(r)
         if errmsg == nil then
@@ -90,9 +97,6 @@ if ngx.config.subsystem == "http" then
         end
 
         local r = get_request()
-        if not r then
-            error("no request found")
-        end
 
         local errmsg = C.ngx_http_lua_kong_ffi_disable_session_reuse(r)
         if errmsg == nil then
@@ -118,9 +122,6 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
-            if not r then
-                error("no request found")
-            end
 
             size_ptr[0] = DEFAULT_CERT_CHAIN_SIZE
 
@@ -173,9 +174,6 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
-            if not r then
-                error("no request found")
-            end
 
             local ret = C.ngx_http_lua_kong_ffi_set_upstream_client_cert_and_key(
                 r, chain, key)
@@ -204,9 +202,6 @@ if ngx.config.subsystem == "http" then
               end
 
               local r = get_request()
-              if not r then
-                  error("no request found")
-              end
 
               local ret = C.ngx_http_lua_kong_ffi_set_upstream_ssl_trusted_store(
                   r, store.ctx)
@@ -232,9 +227,6 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
-            if not r then
-                error("no request found")
-            end
 
             local ret = C.ngx_http_lua_kong_ffi_set_upstream_ssl_verify(
                 r, verify)
@@ -263,9 +255,6 @@ if ngx.config.subsystem == "http" then
             end
 
             local r = get_request()
-            if not r then
-                error("no request found")
-            end
 
             local ret = C.ngx_http_lua_kong_ffi_set_upstream_ssl_verify_depth(
                 r, depth)
@@ -294,9 +283,6 @@ else -- stream
             end
 
             local r = get_request()
-            if not r then
-                error("no request found")
-            end
 
             local ret = C.ngx_stream_lua_kong_ffi_proxy_ssl_disable(r)
             if ret == NGX_OK then

--- a/lualib/resty/kong/var.lua
+++ b/lualib/resty/kong/var.lua
@@ -12,7 +12,7 @@ local assert = assert
 local tostring = tostring
 local tonumber = tonumber
 local getmetatable = getmetatable
-local get_request = base.get_request
+local orig_get_request = base.get_request
 local get_size_ptr = base.get_size_ptr
 local get_phase = ngx.get_phase
 local subsystem = ngx.config.subsystem
@@ -56,6 +56,16 @@ local value_ptr = ffi_new("unsigned char *[1]")
 local errmsg = base.get_errmsg_ptr()
 
 
+local function get_request()
+    local r = orig_get_request()
+
+    if not r then
+        error("no request found")
+    end
+
+    return r
+end
+
 local function load_indexes()
     if get_phase() ~= "init" then
         error("load_indexes can only be called in init phase")
@@ -87,9 +97,6 @@ end
 
 local function var_get_by_index(index)
     local r = get_request()
-    if not r then
-        error("no request found")
-    end
 
     local value_len = get_size_ptr()
 
@@ -114,9 +121,6 @@ end
 
 local function var_set_by_index(index, value)
     local r = get_request()
-    if not r then
-        error("no request found")
-    end
 
     local value_len
     if value == nil then

--- a/src/ngx_http_lua_kong_ssl.c
+++ b/src/ngx_http_lua_kong_ssl.c
@@ -141,7 +141,7 @@ ngx_http_lua_kong_ffi_disable_session_reuse(ngx_http_request_t *r)
     return NULL;
 
 #else
-    return "TLS support is not enabled in Nginx build"
+    return "TLS support is not enabled in Nginx build";
 #endif
 }
 
@@ -174,7 +174,7 @@ ngx_http_lua_kong_ffi_request_client_certificate(ngx_http_request_t *r)
     return NULL;
 
 #else
-    return "TLS support is not enabled in Nginx build"
+    return "TLS support is not enabled in Nginx build";
 #endif
 }
 


### PR DESCRIPTION
Reason of adding this check: 
Although it's indeed redundent given our phase check. but it gives us extra protection because this a private API from openresty, it doesn't guaranteeded to be unchanged in the future. And also given the severity when it happens, it will likely cause a segfault, instead of a lua vm crach.