### PR TITLE
fix(var): patch set_uri_args

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,3 +13,14 @@ not_globals = {
 ignore = {
     "6.", -- ignore whitespace warnings
 }
+
+
+globals = {
+    ngx = {
+        req = {
+            set_uri_args = {
+                read_only = false
+            }
+        }
+    }
+}

--- a/lualib/resty/kong/var.lua
+++ b/lualib/resty/kong/var.lua
@@ -6,6 +6,7 @@ local C = ffi.C
 local ffi_new = ffi.new
 local ffi_str = ffi.string
 local var = ngx.var
+local req = ngx.req
 local type = type
 local error = error
 local assert = assert
@@ -150,6 +151,16 @@ local function var_set_by_index(index, value)
 end
 
 
+local function patch_functions()
+  local orig_set_uri_args = req.set_uri_args
+
+  req.set_uri_args = function(...)
+    variable_index.args = nil
+    return orig_set_uri_args(...)
+  end
+end
+
+
 local function patch_metatable()
     if get_phase() ~= "init" then
         error("patch_metatable can only be called in init phase")
@@ -184,6 +195,8 @@ local function patch_metatable()
 
         return orig_set(self, name, value)
     end
+
+    patch_functions()
 end
 
 


### PR DESCRIPTION
set_uri_args modifies the $args variable without accessing our patched metatable. For it to work properly we can invalidate our index table for the value "args" whenever the function `set_uri_args` is called. This way the next access to ngx.var.args will miss the index and fetch the real value of $args.

fix for https://github.com/Kong/kong/issues/10080

[KAG-410](https://konghq.atlassian.net/browse/KAG-410)

[KAG-410]: https://konghq.atlassian.net/browse/KAG-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ