### PR TITLE
tests: fix failing tests

### DIFF
--- a/t/001-tls.t
+++ b/t/001-tls.t
@@ -21,6 +21,7 @@ __DATA__
 === TEST 1: session reuse by session tickets without disable_session_reuse
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+    lua_ssl_protocols SSLV3 TLSv1 TLSv1.1 TLSv1.2;
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name   example.com;
@@ -91,7 +92,9 @@ SSL reused session
 
 === TEST 2: session reuse by session cache without disable_session_reuse
 --- http_config
+    lua_ssl_protocols SSLV3 TLSv1 TLSv1.1 TLSv1.2;
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name   example.com;
@@ -162,7 +165,9 @@ SSL reused session
 
 === TEST 3: disable_session_reuse can suppress usage of session tickets
 --- http_config
+    lua_ssl_protocols SSLV3 TLSv1 TLSv1.1 TLSv1.2;
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name   example.com;
@@ -235,7 +240,9 @@ SSL reused session
 
 === TEST 4: disable_session_reuse can suppress usage of session cache
 --- http_config
+    lua_ssl_protocols SSLV3 TLSv1 TLSv1.1 TLSv1.2;
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
     server {
         listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
         server_name   example.com;

--- a/t/003-grpc.t
+++ b/t/003-grpc.t
@@ -21,7 +21,8 @@ __DATA__
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock http2;
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        http2 on;
         server_name   example.com;
 
         server_tokens off;
@@ -57,7 +58,8 @@ GET /t
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock http2;
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        http2 on;
         server_name   example.com;
 
         server_tokens off;
@@ -99,7 +101,8 @@ GET /t
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock http2;
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        http2 on;
         server_name   example.com;
 
         server_tokens off;
@@ -142,7 +145,8 @@ GET /t
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock http2;
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        http2 on;
         server_name   example.com;
 
         server_tokens off;
@@ -185,7 +189,8 @@ GET /t
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
     server {
-        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock http2;
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        http2 on;
         server_name   example.com;
 
         server_tokens off;
@@ -231,7 +236,8 @@ falseincorrect argument, expects a string, got number
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
     server {
-        listen 127.0.0.1:12346 http2;
+        listen 127.0.0.1:12346;
+        http2 on;
         server_name   example.com;
 
         server_tokens off;


### PR DESCRIPTION
# Please REBASE AND MERGE

1. The TLS 1.2 Session Resumption via Session Tickets and Session Identifiers mentioned earlier is outdated in TLS 1.3.
2. Replacing `listen ... http2` by `http2 on` to avoid the deprecation message of grpc tests.