### PR TITLE
fix(ssl): add const to ngx_lua_kong_ssl_x509_copy argument

### DIFF
--- a/src/ssl/ngx_lua_kong_ssl.c
+++ b/src/ssl/ngx_lua_kong_ssl.c
@@ -303,7 +303,7 @@ failed:
 
 
 static X509 *
-ngx_lua_kong_ssl_x509_copy(X509 *in)
+ngx_lua_kong_ssl_x509_copy(const X509 *in)
 {
     return X509_up_ref(in) == 0 ? NULL : in;
 }


### PR DESCRIPTION
Fix a warning that is recently being treated as error on macOS.

```
/private/var/tmp/_bazel_fffonion/1a165933b7da774c4bb1daeeee6ca097/execroot/kong/external/lua-kong-nginx-module/src/ssl/ngx_lua_kong_ssl.c:370:42: error: incompatible function pointer types passing 'X509 *(X509 *)' (aka 'struct x509_st *(struct x509_st *)') to parameter of type 'sk_X509_copyfunc' (aka 'struct x509_st *(*)(const struct x509_st *)') [-Wincompatible-function-pointer-types]
    new_chain = sk_X509_deep_copy(chain, ngx_lua_kong_ssl_x509_copy,
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/private/var/tmp/_bazel_fffonion/1a165933b7da774c4bb1daeeee6ca097/execroot/kong/bazel-out/darwin_arm64-fastbuild/bin/external/openresty/openresty.ext_build_deps/openssl/include/openssl/x509.h:102:156: note: expanded from macro 'sk_X509_deep_copy'
#define sk_X509_deep_copy(sk, copyfunc, freefunc) ((STACK_OF(X509) *)OPENSSL_sk_deep_copy(ossl_check_const_X509_sk_type(sk), ossl_check_X509_copyfunc_type(copyfunc), ossl_check_X509_freefunc_type(freefunc)))
                                                                                                                                                           ^~~~~~~~
/private/var/tmp/_bazel_fffonion/1a165933b7da774c4bb1daeeee6ca097/execroot/kong/bazel-out/darwin_arm64-fastbuild/bin/external/openresty/openresty.ext_build_deps/openssl/include/openssl/x509.h:78:1: note: passing argument to parameter 'cpy' here
SKM_DEFINE_STACK_OF_INTERNAL(X509, X509, X509)
^
/private/var/tmp/_bazel_fffonion/1a165933b7da774c4bb1daeeee6ca097/execroot/kong/bazel-out/darwin_arm64-fastbuild/bin/external/openresty/openresty.ext_build_deps/openssl/include/openssl/safestack.h:55:107: note: expanded from macro 'SKM_DEFINE_STACK_OF_INTERNAL'
    static ossl_unused ossl_inline OPENSSL_sk_copyfunc ossl_check_##t1##_copyfunc_type(sk_##t1##_copyfunc cpy) \

```


KAG-4050