### PR TITLE
fix: declare peer_conn can only be used in the http subsystem

### DIFF
--- a/lualib/resty/kong/peer_conn.lua
+++ b/lualib/resty/kong/peer_conn.lua
@@ -6,16 +6,17 @@ local errmsg           = base.get_errmsg_ptr()
 local C                = ffi.C
 local ffi_str          = ffi.string
 local get_phase        = ngx.get_phase
+local subsystem        = ngx.config.subsystem
 local NGX_ERROR        = ngx.ERROR
 
 local error            = error
 
-
-ffi.cdef[[
-int
-ngx_http_lua_kong_ffi_get_last_peer_connection_cached(ngx_http_request_t *r,
-    char **err);
-]]
+if subsystem == "http" then
+    ffi.cdef[[
+    int ngx_http_lua_kong_ffi_get_last_peer_connection_cached(ngx_http_request_t *r,
+        char **err);
+    ]]
+end
 
 
 local function get_last_peer_connection_cached()

--- a/lualib/resty/kong/peer_conn.lua
+++ b/lualib/resty/kong/peer_conn.lua
@@ -5,7 +5,6 @@ local get_request      = base.get_request
 local errmsg           = base.get_errmsg_ptr()
 local C                = ffi.C
 local ffi_str          = ffi.string
-local get_phase        = ngx.get_phase
 local subsystem        = ngx.config.subsystem
 local NGX_ERROR        = ngx.ERROR
 
@@ -16,13 +15,15 @@ local get_last_peer_connection_cached
 
 
 if subsystem == "http" then
+    require "resty.core.phase"  -- for ngx.get_phase
     ffi.cdef[[
     int ngx_http_lua_kong_ffi_get_last_peer_connection_cached(ngx_http_request_t *r,
         char **err);
     ]]
     
     get_last_peer_connection_cached = function()
-        if get_phase() ~= "balancer" then
+        local ngx_phase = ngx.get_phase
+        if ngx_phase() ~= "balancer" then
             error("get_last_peer_connection_cached() can only be called in balancer phase")
         end
     

--- a/lualib/resty/kong/peer_conn.lua
+++ b/lualib/resty/kong/peer_conn.lua
@@ -16,13 +16,13 @@ local get_last_peer_connection_cached
 
 if subsystem == "http" then
     require "resty.core.phase"  -- for ngx.get_phase
+    local ngx_phase = ngx.get_phase
     ffi.cdef[[
     int ngx_http_lua_kong_ffi_get_last_peer_connection_cached(ngx_http_request_t *r,
         char **err);
     ]]
     
     get_last_peer_connection_cached = function()
-        local ngx_phase = ngx.get_phase
         if ngx_phase() ~= "balancer" then
             error("get_last_peer_connection_cached() can only be called in balancer phase")
         end


### PR DESCRIPTION
this PR is an additional section of #82 that ensures `peer_conn` is used correctly under the http subsystem.

Fix [FTI-5616](https://konghq.atlassian.net/browse/FTI-5616)

[FTI-5616]: https://konghq.atlassian.net/browse/FTI-5616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ