### PR TITLE
feat: support extended debug levels

### DIFF
--- a/src/ngx_http_lua_kong_log.c
+++ b/src/ngx_http_lua_kong_log.c
@@ -59,7 +59,7 @@ ngx_http_lua_kong_ffi_set_dynamic_log_level(int log_level, int timeout)
     ** we will not change the current log level,
     ** and return an error.
     */
-    if (log_level > NGX_LOG_DEBUG || log_level < NGX_LOG_STDERR) {
+    if (log_level > NGX_LOG_DEBUG_LAST || log_level < NGX_LOG_STDERR) {
         return NGX_ERROR;
     }
 

--- a/t/008-log.t
+++ b/t/008-log.t
@@ -938,3 +938,32 @@ GET /test
 ]
 --- no_log eval
 "you can't see me init_worker"
+
+
+
+=== TEST 25: set_log_level and get_log_level support extended Nginx debug levels
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+--- config
+    location = /test {
+        content_by_lua_block {
+            local log = require("resty.kong.log")
+            local DEBUG_MAIL = 0x200
+
+            assert(pcall(log.set_log_level, DEBUG_MAIL, 2))
+            assert(log.get_log_level(ngx.WARN) == DEBUG_MAIL)
+
+            ngx.sleep(3)
+            assert(log.get_log_level(ngx.WARN) == ngx.WARN)
+
+            ngx.say("ok")
+        }
+    }
+--- timeout: 5s
+--- request
+GET /test
+--- response_body
+ok
+--- no_error_log
+[error]
+[crit]


### PR DESCRIPTION
Expose [seven additional Nginx log levels](https://github.com/nginx/nginx/blob/release-1.25.4/src/core/ngx_log.h#L26-L32) that are not normally exposed by OpenResty, which allows for finer-grained debugging with less noise in the debug-level logs: `debug_core`, `debug_alloc`, `debug_mutex`, `debug_event`, `debug_http`, `debug_mail`, `debug_stream`.

By setting a quieter value such as `debug_mail`, Kong Gateway debug logs are usable again, as the Kong (and WasmX) logs are still shown, but the other Nginx debug logs (memory allocations, etc.) are not shown.