### PR TITLE
docs: specify `timeout` unit for `resty.kong.log.get_log_level()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,8 +471,7 @@ resty.kong.log.get\_log\_level
 
 Returns the current dynamic log level, remaining timeout and the original log level.
 
-If the dynamic log level is not set or not active,
-`timeout` will be `0`.
+`timeout` is in whole seconds, as an integer. If the dynamic log level is not set or not active, `timeout` will be `0`.
 
 Please see [Nginx log level constants](https://github.com/openresty/lua-nginx-module#nginx-log-level-constants)
 for the possible value of `level`.

--- a/README.md
+++ b/README.md
@@ -469,9 +469,11 @@ resty.kong.log.get\_log\_level
 
 **subsystems:** *http*
 
-Returns the current dynamic log level, remaining timeout and the original log level.
+Returns the current dynamic log level, remaining timeout (in seconds),
+and the original log level.
 
-`timeout` is in whole seconds, as an integer. If the dynamic log level is not set or not active, `timeout` will be `0`.
+If the dynamic log level is not set or not active,
+the `timeout` will be `0`.
 
 Please see [Nginx log level constants](https://github.com/openresty/lua-nginx-module#nginx-log-level-constants)
 for the possible value of `level`.


### PR DESCRIPTION
Reference the effect [here](https://github.com/Kong/lua-kong-nginx-module/tree/doc/new_get_log_level?tab=readme-ov-file#restykonglogget_log_level).