### PR TITLE
chore(ci): revert the kong version back to master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  KONG_VERSION: disable-h2-alpn-re
+  KONG_VERSION: master
   BUILD_ROOT: ${{ github.workspace }}/kong/bazel-bin/build
 
 concurrency:


### PR DESCRIPTION
This was temporary changed in #93  to break circular depedency.
