### PR TITLE
fix(var): patch set_header

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,9 @@ globals = {
         req = {
             set_uri_args = {
                 read_only = false
+            },
+            set_header = {
+                read_only = false
             }
         }
     }

--- a/lualib/resty/kong/var.lua
+++ b/lualib/resty/kong/var.lua
@@ -24,6 +24,8 @@ local NGX_DECLINED = ngx.DECLINED
 
 local variable_index = {}
 local metatable_patched
+local str_replace_char
+local replace_dashes_lower
 
 
 --Add back if stream module is implemented to aid readability
@@ -50,6 +52,11 @@ if subsystem == "http" then
     --ngx_lua_kong_ffi_var_get_by_index = C.ngx_http_lua_kong_ffi_var_get_by_index
     --ngx_lua_kong_ffi_var_set_by_index = C.ngx_http_lua_kong_ffi_var_set_by_index
     --ngx_lua_kong_ffi_var_load_indexes = C.ngx_http_lua_kong_ffi_var_load_indexes
+    
+    str_replace_char = require("resty.core.utils").str_replace_char
+    replace_dashes_lower = function(str)
+        return str_replace_char(str:lower(), "-", "_")
+    end
 end
 
 
@@ -158,6 +165,16 @@ local function patch_functions()
   req.set_uri_args = function(...)
     variable_index.args = nil
     return orig_set_uri_args(...)
+  end
+  
+  local orig_set_header = req.set_header
+
+  req.set_header = function(...)
+    local normalized_header = replace_dashes_lower(...)
+    normalized_header = "http_" .. normalized_header
+    variable_index[normalized_header] = nil
+
+    return orig_set_header(...)
   end
 end
 

--- a/lualib/resty/kong/var.lua
+++ b/lualib/resty/kong/var.lua
@@ -27,7 +27,7 @@ local metatable_patched
 local str_replace_char
 local replace_dashes_lower
 
-   local HTTP_PREFIX = "http_"
+local HTTP_PREFIX = "http_"
 
 --Add back if stream module is implemented to aid readability
 --see bottom of: https://luajit.org/ext_ffi_tutorial.html

--- a/lualib/resty/kong/var.lua
+++ b/lualib/resty/kong/var.lua
@@ -27,6 +27,7 @@ local metatable_patched
 local str_replace_char
 local replace_dashes_lower
 
+   local HTTP_PREFIX = "http_"
 
 --Add back if stream module is implemented to aid readability
 --see bottom of: https://luajit.org/ext_ffi_tutorial.html
@@ -169,12 +170,12 @@ local function patch_functions()
   
   local orig_set_header = req.set_header
 
-  req.set_header = function(...)
-    local normalized_header = replace_dashes_lower(...)
-    normalized_header = "http_" .. normalized_header
+  req.set_header = function(name, value)
+    local normalized_header = replace_dashes_lower(name)
+    normalized_header = HTTP_PREFIX .. normalized_header
     variable_index[normalized_header] = nil
 
-    return orig_set_header(...)
+    return orig_set_header(name, value)
   end
 end
 


### PR DESCRIPTION
patch the `req.set_header` function to invalidate the relevant `variable_index` entry for the modified header. Specifically, after normalizing the header name, the corresponding `variable_index` entry is set to `nil`. This ensures that subsequent accesses to `ngx.var.http_*` variables will bypass the cached index and fetch the updated header value.

same fix way as: https://github.com/Kong/lua-kong-nginx-module/pull/59

Fix: [KAG-5963](https://konghq.atlassian.net/browse/KAG-5963)
Fix: [FTI-6406](https://konghq.atlassian.net/browse/FTI-6406)

[KAG-5963]: https://konghq.atlassian.net/browse/KAG-5963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



[FTI-6406]: https://konghq.atlassian.net/browse/FTI-6406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ