### PR TITLE
chore: restore github action kong version to master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  KONG_VERSION: feat-next-upstream
+  KONG_VERSION: master
   BUILD_ROOT: ${{ github.workspace }}/kong/bazel-bin/build
 
 concurrency:


### PR DESCRIPTION
fixing the test kong branch to master which https://github.com/Kong/lua-kong-nginx-module/pull/98 changed.