### PR TITLE
fix(var): patch set_header 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  KONG_VERSION: master
+  KONG_VERSION: release/3.4.x
   BUILD_ROOT: ${{ github.workspace }}/kong/bazel-bin/build
 
 concurrency:
@@ -63,6 +63,22 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         cd kong
+        
+        # Find the .rockspec file (handles varying filenames like kong-3.4.x-0.rockspec)
+        ROCKSPEC_FILE=$(ls kong-*.rockspec | head -n 1)
+        
+        # Check if the rockspec file exists
+        if [[ -f "$ROCKSPEC_FILE" ]]; then
+          echo "Modifying lua-messagepack version in $ROCKSPEC_FILE"
+          
+          # Use sed to replace "lua-messagepack == 0.5.2" with "lua-messagepack == 0.5.4"
+          sed -i 's/"lua-messagepack == 0\.5\.2"/"lua-messagepack == 0.5.4"/' "$ROCKSPEC_FILE"
+        else
+          echo "Error: .rockspec file not found!"
+          exit 1
+        fi
+
+        # Proceed with the build steps
         make build-kong
         make build-venv
         BUILD_PREFIX=$BUILD_ROOT/kong-dev

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,9 @@ globals = {
         req = {
             set_uri_args = {
                 read_only = false
+            },
+            set_header = {
+                read_only = false
             }
         }
     }

--- a/lualib/resty/kong/var.lua
+++ b/lualib/resty/kong/var.lua
@@ -24,7 +24,10 @@ local NGX_DECLINED = ngx.DECLINED
 
 local variable_index = {}
 local metatable_patched
+local str_replace_char
+local replace_dashes_lower
 
+local HTTP_PREFIX = "http_"
 
 --Add back if stream module is implemented to aid readability
 --see bottom of: https://luajit.org/ext_ffi_tutorial.html
@@ -50,6 +53,11 @@ if subsystem == "http" then
     --ngx_lua_kong_ffi_var_get_by_index = C.ngx_http_lua_kong_ffi_var_get_by_index
     --ngx_lua_kong_ffi_var_set_by_index = C.ngx_http_lua_kong_ffi_var_set_by_index
     --ngx_lua_kong_ffi_var_load_indexes = C.ngx_http_lua_kong_ffi_var_load_indexes
+    
+    str_replace_char = require("resty.core.utils").str_replace_char
+    replace_dashes_lower = function(str)
+        return str_replace_char(str:lower(), "-", "_")
+    end
 end
 
 
@@ -157,6 +165,16 @@ local function patch_functions()
   req.set_uri_args = function(...)
     variable_index.args = nil
     return orig_set_uri_args(...)
+  end
+  
+  local orig_set_header = req.set_header
+
+  req.set_header = function(name, value)
+    local normalized_header = replace_dashes_lower(name)
+    normalized_header = HTTP_PREFIX .. normalized_header
+    variable_index[normalized_header] = nil
+
+    return orig_set_header(name, value)
   end
 end
 

--- a/t/stream/001-upstream-tls.t
+++ b/t/stream/001-upstream-tls.t
@@ -19,36 +19,98 @@ run_tests();
 __DATA__
 
 === TEST 1: upstream TLS proxying works
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   example.com;
+        ssl_certificate ../../cert/example.com.crt;
+        ssl_certificate_key ../../cert/example.com.key;
+
+        server_tokens off;
+
+        location /foo {
+            default_type 'text/plain';
+            more_clear_headers Date;
+            echo 'it works!';
+        }
+    }
+--- stream_config
+    upstream foo {
+        server unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+    }
 --- stream_server_config
-    proxy_pass mockbin.com:443;
+    proxy_ssl_trusted_certificate ../../cert/ca.crt;
+    proxy_ssl_verify on;
+    proxy_ssl_name example.com;
     proxy_ssl on;
-    proxy_ssl_server_name on;
+
+    proxy_pass foo;
+    proxy_ssl_session_reuse off;
+
 --- stream_request eval
-"GET / HTTP/1.0\r\nHost: mockbin.com\r\n\r\n"
---- stream_response_like: ^HTTP/1.1 200 OK
+"GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"
+
+--- stream_response_like
+it works!
+
 --- no_error_log
 [error]
 
 
 
 === TEST 2: upstream plaintext proxying works
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        server_name   example.com;
+
+        server_tokens off;
+
+        location /foo {
+            default_type 'text/plain';
+            more_clear_headers Date;
+            echo 'it works!';
+        }
+    }
+--- stream_config
+    upstream foo {
+        server unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+    }
 --- stream_server_config
-    proxy_pass mockbin.com:80;
     proxy_ssl off;
+    proxy_pass foo;
+
 --- stream_request eval
-"GET / HTTP/1.0\r\nHost: mockbin.com\r\n\r\n"
---- stream_response_like: ^HTTP/1.1 200 OK
+"GET /foo HTTP/1.0\r\nHost: example.com\r\n\r\n"
+
+--- stream_response_like
+it works!
+
 --- no_error_log
 [error]
 
 
 
 === TEST 3: upstream TLS proxying inhibit works
---- stream_config
+--- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name   example.com;
+        ssl_certificate ../../cert/example.com.crt;
+        ssl_certificate_key ../../cert/example.com.key;
+
+        server_tokens off;
+    }
+--- stream_config
+    proxy_ssl_session_reuse off;
 --- stream_server_config
-    proxy_pass mockbin.com:443;
+    proxy_pass unix:$TEST_NGINX_HTML_DIR/nginx.sock;
     proxy_ssl on;
 
     preread_by_lua_block {
@@ -57,7 +119,7 @@ __DATA__
         assert(tls.disable_proxy_ssl())
     }
 --- stream_request eval
-"GET / HTTP/1.0\r\nHost: mockbin.com\r\n\r\n"
+"GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
 --- stream_response_like: ^.+400 The plain HTTP request was sent to HTTPS port.+$
 --- no_error_log
 [error]
@@ -99,7 +161,7 @@ __DATA__
     proxy_pass unix:$TEST_NGINX_HTML_DIR/nginx.sock;
 
 --- stream_request eval
-"GET / HTTP/1.0\r\nHost: mockbin.com\r\n\r\n"
+"GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
 
 --- stream_response_like
 ^.+No required SSL certificate was sent.+


### PR DESCRIPTION
patch the req.set_header function to invalidate the relevant variable_index entry for the modified header. Specifically, after normalizing the header name, the corresponding variable_index entry is set to nil. This ensures that subsequent accesses to ngx.var.http_* variables will bypass the cached index and fetch the updated header value.

same fix way as: https://github.com/Kong/lua-kong-nginx-module/pull/59

Fix: [KAG-5963](https://konghq.atlassian.net/browse/KAG-5963)
Fix: [FTI-6406](https://konghq.atlassian.net/browse/FTI-6406)

Signed-off-by: tzssangglass <tzssangglass@gmail.com>

[KAG-5963]: https://konghq.atlassian.net/browse/KAG-5963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTI-6406]: https://konghq.atlassian.net/browse/FTI-6406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ