### PR TITLE
chore(ci): update GitHub Actions workflow to remove rockspec modification step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,22 +63,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         cd kong
-        
-        # Find the .rockspec file (handles varying filenames like kong-3.4.x-0.rockspec)
-        ROCKSPEC_FILE=$(ls kong-*.rockspec | head -n 1)
-        
-        # Check if the rockspec file exists
-        if [[ -f "$ROCKSPEC_FILE" ]]; then
-          echo "Modifying lua-messagepack version in $ROCKSPEC_FILE"
-          
-          # Use sed to replace "lua-messagepack == 0.5.2" with "lua-messagepack == 0.5.4"
-          sed -i 's/"lua-messagepack == 0\.5\.2"/"lua-messagepack == 0.5.4"/' "$ROCKSPEC_FILE"
-        else
-          echo "Error: .rockspec file not found!"
-          exit 1
-        fi
 
-        # Proceed with the build steps
         make build-kong
         make build-venv
         BUILD_PREFIX=$BUILD_ROOT/kong-dev


### PR DESCRIPTION
removed the logic for modifying the lua-messagepack version in the .rockspec file from the CI workflow.

releated to:https://github.com/Kong/kong/pull/14061

Signed-off-by: tzssangglass <tzssangglass@gmail.com>