### PR TITLE
fix(var): patch set_header

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  KONG_VERSION: master
+  KONG_VERSION: release/3.9.x
   BUILD_ROOT: ${{ github.workspace }}/kong/bazel-bin/build
 
 concurrency:

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,9 @@ globals = {
         req = {
             set_uri_args = {
                 read_only = false
+            },
+            set_header = {
+                read_only = false
             }
         }
     }


### PR DESCRIPTION
patch the `req.set_header` function to invalidate the relevant `variable_index` entry for the modified header. Specifically, after normalizing the header name, the corresponding `variable_index` entry is set to `nil`. This ensures that subsequent accesses to `ngx.var.http_*` variables will bypass the cached index and fetch the updated header value.

same fix way as: https://github.com/Kong/lua-kong-nginx-module/pull/59

Fix: KAG-5963
Fix: FTI-6406