### PR TITLE
feat(vars): index upstream timing variables for FFI access

### DIFF
--- a/src/ngx_http_lua_kong_var_index.c
+++ b/src/ngx_http_lua_kong_var_index.c
@@ -91,6 +91,13 @@ static ngx_str_t default_vars[] = {
     ngx_string("upstream_http_upgrade"),
     ngx_string("upstream_status"),
 
+    /* detailed upstream timing vars */
+    ngx_string("upstream_start_timestamp_us"),
+    ngx_string("upstream_connect_timestamp_us"),
+    ngx_string("upstream_request_timestamp_us"),
+    ngx_string("upstream_header_timestamp_us"),
+    ngx_string("upstream_response_timestamp_us"),
+
     /* lua-kong-module vars */
     ngx_string("kong_request_id"),
 

--- a/t/006-default_indexed-var.t
+++ b/t/006-default_indexed-var.t
@@ -9,7 +9,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 8) + 10;
+plan tests => repeat_each() * (blocks() * 8) + 14;
 
 #no_diff();
 #no_long_string();
@@ -440,6 +440,39 @@ true 12345 false
 get variable value 'true' by index
 get variable value '12345' by index
 get variable value 'false' by index
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+=== TEST 14: upstream timing variables
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+    lua_kong_load_var_index default;
+    init_by_lua_block {
+        require("resty.kong.var").patch_metatable()
+    }
+
+--- config
+    location = /test {
+        content_by_lua_block {
+            ngx.say(ngx.var.upstream_start_timestamp_us, " ",
+                    ngx.var.upstream_connect_timestamp_us, " ",
+                    ngx.var.upstream_request_timestamp_us, " ",
+                    ngx.var.upstream_header_timestamp_us, " ",
+                    ngx.var.upstream_response_timestamp_us)
+        }
+    }
+--- request
+GET /test
+--- response_body
+nil nil nil nil nil
+--- error_log
+variable value is not found by index
+variable value is not found by index
+variable value is not found by index
+variable value is not found by index
+variable value is not found by index
 --- no_error_log
 [error]
 [crit]


### PR DESCRIPTION
We have identified a ~5% RPS performance regression in the Kong EE PR 11452

Upon further investigation, we found that a big chunk of CPU time is spent on ngx.var variables access.

We add upstream timing variables to the default indexed variables list, allowing efficient access through Kong's FFI interface. These variables track detailed timing information for upstream connections:

* upstream_start_timestamp_us
* upstream_connect_timestamp_us
* upstream_request_timestamp_us
* upstream_header_timestamp_us
* upstream_response_timestamp_us

These microsecond-precision timestamps enable detailed upstream latency analysis and troubleshooting of connection issues.