### PR TITLE
fix(vars): remove request_time from default indexed variables

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   tests:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout source code

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ index *commonly used variables* as follows:
 - `$remote_port`
 - `$request_length`
 - `$request_method`
-- `$request_time`
 - `$request_uri`
 - `$scheme`
 - `$server_addr`

--- a/src/ngx_http_lua_kong_var_index.c
+++ b/src/ngx_http_lua_kong_var_index.c
@@ -71,7 +71,6 @@ static ngx_str_t default_vars[] = {
     /* ngx_string("request"), */
     ngx_string("request_length"),
     ngx_string("request_method"),
-    ngx_string("request_time"),
     ngx_string("request_uri"),
     ngx_string("scheme"),
     ngx_string("server_addr"),

--- a/t/006-default_indexed-var.t
+++ b/t/006-default_indexed-var.t
@@ -9,7 +9,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 8) + 14;
+plan tests => repeat_each() * (blocks() * 8) + 12;
 
 #no_diff();
 #no_long_string();
@@ -205,7 +205,6 @@ get variable value '666' by index
             ngx.say(ngx.var.request_method, " ",
                     ngx.var.request_length, " ",
                     ngx.var.request_uri, " ",
-                    ngx.var.request_time, " ",
                     ngx.var.server_addr, " ",
                     ngx.var.server_port
                     )
@@ -214,12 +213,11 @@ get variable value '666' by index
 --- request
 GET /test
 --- response_body
-GET 58 /test 0.000 127.0.0.1 1984
+GET 58 /test 127.0.0.1 1984
 --- error_log
 get variable value 'GET' by index
 get variable value '58' by index
 get variable value '/test' by index
-get variable value '0.000' by index
 get variable value '127.0.0.1' by index
 get variable value '1984' by index
 --- no_error_log


### PR DESCRIPTION
The request_time variable was previously indexed by default in the NGINX module. However, this behavior is problematic because request_time is a dynamic value that changes over the request lifecycle. Indexing it causes the first access to cache its value, leading to incorrect results for subsequent accesses.

This issue is particularly impactful in Active Tracing, where request_time is used during the log phase. The cached value can result in inaccurate tracing data. This is because the first access to this variable will cache it and subsequent accesses will use the cached value.

This commit removes request_time from the list of default indexed variables to ensure its value is always retrieved dynamically. Corresponding test cases have been updated to reflect this change.

Fix KAG-6868