### PR TITLE
feat(tls): add SANs support for both DNS-names and URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Table of Contents
     * [resty.kong.tls.disable\_session\_reuse](#restykongtlsdisable_session_reuse)
     * [resty.kong.tls.get\_full\_client\_certificate\_chain](#restykongtlsget_full_client_certificate_chain)
     * [resty.kong.tls.set\_upstream\_cert\_and\_key](#restykongtlsset_upstream_cert_and_key)
+    * [resty.kong.tls.set\_upstream\_ssl\_sans\_dnsnames](#restykongtlsset_upstream_ssl_sans_dnsnames)
+    * [resty.kong.tls.set\_upstream\_ssl\_sans\_uris](#restykongtlsset_upstream_ssl_sans_uris)
     * [resty.kong.tls.set\_upstream\_ssl\_trusted\_store](#restykongtlsset_upstream_ssl_trusted_store)
     * [resty.kong.tls.set\_upstream\_ssl\_verify](#restykongtlsset_upstream_ssl_verify)
     * [resty.kong.tls.set\_upstream\_ssl\_verify\_depth](#restykongtlsset_upstream_ssl_verify_depth)
@@ -252,6 +254,44 @@ functions such as [ngx.ssl.parse\_pem\_priv\_key](https://github.com/openresty/l
 On success, this function returns `true` and future handshakes with upstream servers
 will always use the provided client certificate. Otherwise `nil` and a string describing the error
 will be returned.
+
+This function can be called multiple times in the same request. Later calls override
+previous ones.
+
+[Back to TOC](#table-of-contents)
+
+resty.kong.tls.set\_upstream\_ssl\_sans\_dnsnames
+-----------------------------------------
+**syntax:** *ok, err = resty.kong.tls.set\_upstream\_ssl\_sans\_dnsnames(entries)*
+
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, balancer_by_lua&#42;*, *preread_by_lua&#42;*
+
+**subsystems:** *http* *stream*
+
+Set additional SANs entries for name validation of upstream ssl certificate,
+where `entries` is an array of DNS-names.
+
+On success, this function returns `true`. Otherwise `nil` and a string
+describing the error will be returned.
+
+This function can be called multiple times in the same request. Later calls override
+previous ones.
+
+[Back to TOC](#table-of-contents)
+
+resty.kong.tls.set\_upstream\_ssl\_sans\_uris
+-----------------------------------------
+**syntax:** *ok, err = resty.kong.tls.set\_upstream\_ssl\_sans\_uris(entries)*
+
+**context:** *rewrite_by_lua&#42;, access_by_lua&#42;, balancer_by_lua&#42;*, *preread_by_lua&#42;*
+
+**subsystems:** *http* *stream*
+
+Set additional SANs entries for name validation of upstream ssl certificate,
+where `entries` is an array of URIs.
+
+On success, this function returns `true`. Otherwise `nil` and a string
+describing the error will be returned.
 
 This function can be called multiple times in the same request. Later calls override
 previous ones.

--- a/src/ngx_http_lua_kong_module.h
+++ b/src/ngx_http_lua_kong_module.h
@@ -44,4 +44,10 @@ ngx_flag_t
 ngx_http_lua_kong_get_next_upstream_mask(ngx_http_request_t *r,
     ngx_flag_t upstream_next);
 
+ngx_str_t *
+ngx_http_lua_kong_ssl_get_upstream_ssl_sans_dnsnames(ngx_http_request_t *r);
+
+ngx_str_t *
+ngx_http_lua_kong_ssl_get_upstream_ssl_sans_uris(ngx_http_request_t *r);
+
 #endif /* _NGX_HTTP_LUA_KONG_MODULE_H_INCLUDED_ */

--- a/src/ngx_http_lua_kong_ssl.c
+++ b/src/ngx_http_lua_kong_ssl.c
@@ -242,6 +242,93 @@ ngx_http_lua_ffi_disable_http2_alpn(ngx_http_request_t *r, char **err)
     return NGX_OK;
 }
 
+
+int
+ngx_http_lua_kong_ffi_set_upstream_ssl_sans_dnsnames(ngx_http_request_t *r,
+    const char *input, size_t input_len)
+{
+    u_char                      *sans_data;
+    ngx_http_lua_kong_ctx_t     *ctx;
+
+    ctx = ngx_http_lua_kong_get_module_ctx(r);
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    sans_data = ngx_palloc(r->pool, input_len);
+    if (sans_data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_memcpy(sans_data, input, input_len);
+
+    ctx->ssl_ctx.upstream_ssl_sans_dnsnames.data = sans_data;
+    ctx->ssl_ctx.upstream_ssl_sans_dnsnames.len = input_len;
+
+    return NGX_OK;
+}
+
+
+ngx_str_t *
+ngx_http_lua_kong_ssl_get_upstream_ssl_sans_dnsnames(ngx_http_request_t *r)
+{
+    ngx_http_lua_kong_ctx_t     *ctx;
+
+    ctx = ngx_http_lua_kong_get_module_ctx(r);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    if (ctx->ssl_ctx.upstream_ssl_sans_dnsnames.len == 0) {
+        return NULL;
+    }
+
+    return &ctx->ssl_ctx.upstream_ssl_sans_dnsnames;
+}
+
+int
+ngx_http_lua_kong_ffi_set_upstream_ssl_sans_uris(ngx_http_request_t *r,
+    const char *input, size_t input_len)
+{
+    u_char                      *sans_data;
+    ngx_http_lua_kong_ctx_t     *ctx;
+
+    ctx = ngx_http_lua_kong_get_module_ctx(r);
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    sans_data = ngx_palloc(r->pool, input_len);
+    if (sans_data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_memcpy(sans_data, input, input_len);
+
+    ctx->ssl_ctx.upstream_ssl_sans_uris.data = sans_data;
+    ctx->ssl_ctx.upstream_ssl_sans_uris.len = input_len;
+
+    return NGX_OK;
+}
+
+
+ngx_str_t *
+ngx_http_lua_kong_ssl_get_upstream_ssl_sans_uris(ngx_http_request_t *r)
+{
+    ngx_http_lua_kong_ctx_t     *ctx;
+
+    ctx = ngx_http_lua_kong_get_module_ctx(r);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    if (ctx->ssl_ctx.upstream_ssl_sans_uris.len == 0) {
+        return NULL;
+    }
+
+    return &ctx->ssl_ctx.upstream_ssl_sans_uris;
+}
+
 #endif
 
 

--- a/src/ssl/ngx_lua_kong_ssl.h
+++ b/src/ssl/ngx_lua_kong_ssl.h
@@ -24,6 +24,9 @@ typedef struct {
     EVP_PKEY           *upstream_client_private_key;
     X509_STORE         *upstream_trusted_store;
     ngx_uint_t          upstream_ssl_verify_depth;
+    // TODO(lucab): consider changing these two SANs fields into arrays of strings.
+    ngx_str_t           upstream_ssl_sans_dnsnames;
+    ngx_str_t           upstream_ssl_sans_uris;
     unsigned            upstream_ssl_verify:1;
     unsigned            upstream_ssl_verify_set:1;
     unsigned            upstream_ssl_verify_depth_set:1;

--- a/stream/src/ngx_stream_lua_kong_module.c
+++ b/stream/src/ngx_stream_lua_kong_module.c
@@ -297,6 +297,90 @@ ngx_stream_lua_kong_get_upstream_ssl_verify(ngx_stream_session_t *s,
 
     return ngx_lua_kong_ssl_get_upstream_ssl_verify(&ctx->ssl_ctx, proxy_ssl_verify);
 }
+
+int
+ngx_stream_lua_kong_ffi_set_upstream_ssl_sans_dnsnames(ngx_stream_lua_request_t *r,
+    const char *input, size_t input_len)
+{
+    u_char                      *sans_data;
+    ngx_stream_lua_kong_ctx_t   *ctx;
+
+    ctx = ngx_stream_lua_kong_get_module_ctx(r);
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    sans_data = ngx_palloc(r->pool, input_len);
+    if (sans_data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_memcpy(sans_data, input, input_len);
+
+    ctx->ssl_ctx.upstream_ssl_sans_dnsnames.data = sans_data;
+    ctx->ssl_ctx.upstream_ssl_sans_dnsnames.len = input_len;
+
+    return NGX_OK;
+}
+
+ngx_str_t *
+ngx_stream_lua_kong_get_upstream_ssl_sans_dnsnames(ngx_stream_session_t *s)
+{
+    ngx_stream_lua_kong_ctx_t   *ctx;
+
+    ctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_kong_module);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    if (ctx->ssl_ctx.upstream_ssl_sans_dnsnames.len == 0) {
+        return NULL;
+    }
+
+    return &ctx->ssl_ctx.upstream_ssl_sans_dnsnames;
+}
+
+int
+ngx_stream_lua_kong_ffi_set_upstream_ssl_sans_uris(ngx_stream_lua_request_t *r,
+    const char *input, size_t input_len)
+{
+    u_char                      *sans_data;
+    ngx_stream_lua_kong_ctx_t   *ctx;
+
+    ctx = ngx_stream_lua_kong_get_module_ctx(r);
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+
+    sans_data = ngx_palloc(r->pool, input_len);
+    if (sans_data == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_memcpy(sans_data, input, input_len);
+
+    ctx->ssl_ctx.upstream_ssl_sans_uris.data = sans_data;
+    ctx->ssl_ctx.upstream_ssl_sans_uris.len = input_len;
+
+    return NGX_OK;
+}
+
+ngx_str_t *
+ngx_stream_lua_kong_get_upstream_ssl_sans_uris(ngx_stream_session_t *s)
+{
+    ngx_stream_lua_kong_ctx_t   *ctx;
+
+    ctx = ngx_stream_get_module_ctx(s, ngx_stream_lua_kong_module);
+    if (ctx == NULL) {
+        return NULL;
+    }
+
+    if (ctx->ssl_ctx.upstream_ssl_sans_uris.len == 0) {
+        return NULL;
+    }
+
+    return &ctx->ssl_ctx.upstream_ssl_sans_uris;
+}
 #endif
 
 

--- a/stream/src/ngx_stream_lua_kong_module.h
+++ b/stream/src/ngx_stream_lua_kong_module.h
@@ -32,6 +32,12 @@ ngx_flag_t
 ngx_stream_lua_kong_get_upstream_ssl_verify(ngx_stream_session_t *s,
     ngx_flag_t proxy_ssl_verify);
 
+ngx_str_t *
+ngx_stream_lua_kong_get_upstream_ssl_sans_dnsnames(ngx_stream_session_t *s);
+
+ngx_str_t *
+ngx_stream_lua_kong_get_upstream_ssl_sans_uris(ngx_stream_session_t *s);
+
 #endif
 
 #endif /* _NGX_STREAM_LUA_KONG_MODULE_H_INCLUDED_ */


### PR DESCRIPTION
This adds two new Lua functions (and the corresponding C logic) to configure custom SANs validation in nginx:
 * `resty.kong.tls.set_upstream_ssl_sans_dnsnames()`
 * `resty.kong.tls.set_upstream_ssl_sans_uris()`

Part of KAG-6247.

---

Notes:
 * This requires a corresponding nginx patch implementing the additional TLS-name validation logic.
 * Testing for this change (and the above nginx patch) is done at the integration level in Kong, see linked PR.