### PR TITLE
Revert "chore(*): make test pass - revert this before releasing"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  KONG_VERSION: refactor/patches-h2-alpn-removal
+  KONG_VERSION: master
   BUILD_ROOT: ${{ github.workspace }}/kong/bazel-bin/build
 
 concurrency:


### PR DESCRIPTION
This reverts commit 3f305911823301a98a12ec6ecdd9070b8ebe499b.

Original "make test pass - revert this **before** releasing"  message should have been "make test pass - revert this **after** releasing". But yes, now that CE PR is merged we don't need to point anymore to non-master branch for this repo to be green.