### PR TITLE
feat(vars): add $kong_client_addr variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Table of Contents
     * [$kong\_upstream\_ssl\_server\_raw\_cert](#kong_upstream_ssl_server_raw_cert)
     * [$kong\_upstream\_ssl\_protocol](#kong_upstream_ssl_protocol)
     * [$kong\_worker\_connections\_free](#kong_worker_connections_free)
+    * [$kong\_client\_addr](#kong_client_addr)
 * [Methods](#methods)
     * [resty.kong.tls.disable\_session\_reuse](#restykongtlsdisable_session_reuse)
     * [resty.kong.tls.get\_full\_client\_certificate\_chain](#restykongtlsget_full_client_certificate_chain)
@@ -138,6 +139,7 @@ index *commonly used variables* as follows:
 - `$upstream_header_timestamp_us`
 - `$upstream_response_timestamp_us`
 - `$kong_request_id`
+- `$kong_client_addr`
 
 See [resty.kong.var.patch\_metatable](#restykongvarpatch_metatable) on how to enable
 indexed variable access.
@@ -211,6 +213,20 @@ Returns the number of free (unused) connection slots currently available
 in this worker process. This is the live value of
 `ngx_cycle->free_connection_n` and reflects real-time connection pressure
 on the worker.
+
+[Back to TOC](#table-of-contents)
+
+$kong\_client\_addr
+--------------------
+
+Returns the client address, considering the PROXY protocol.
+When the connection uses PROXY protocol and the `proxy_protocol_addr`
+differs from `remote_addr`, and `remote_addr` is trusted (as configured
+by `set_real_ip_from`), this variable returns the `proxy_protocol_addr`.
+Otherwise it returns `remote_addr`.
+
+This variable is only available when Nginx is built with
+`--with-http_realip_module`.
 
 [Back to TOC](#table-of-contents)
 

--- a/src/ngx_http_lua_kong_var_index.c
+++ b/src/ngx_http_lua_kong_var_index.c
@@ -64,6 +64,7 @@ static ngx_str_t default_vars[] = {
 #if (NGX_HTTP_REALIP)
     ngx_string("realip_remote_addr"),
     ngx_string("realip_remote_port"),
+    ngx_string("kong_client_addr"),
 #endif
 
     /* ngx_string("remote_addr"), */

--- a/src/ngx_http_lua_kong_vars.c
+++ b/src/ngx_http_lua_kong_vars.c
@@ -232,6 +232,75 @@ ngx_http_lua_kong_variable_worker_connections_free(ngx_http_request_t *r,
 }
 
 
+#if (NGX_HTTP_REALIP)
+
+extern ngx_module_t  ngx_http_realip_module;
+
+static ngx_int_t
+ngx_http_lua_kong_variable_client_addr(ngx_http_request_t *r,
+    ngx_http_variable_value_t *v, uintptr_t data)
+{
+    ngx_connection_t       *c;
+    ngx_str_t              *remote_addr;
+    ngx_str_t              *pp_addr;
+    ngx_array_t            *from;
+    void                   *rlcf;
+
+    c = r->connection;
+    remote_addr = &c->addr_text;
+
+    /* check if proxy_protocol_addr is available and non-empty */
+    if (c->proxy_protocol == NULL
+        || c->proxy_protocol->src_addr.len == 0)
+    {
+        goto use_remote_addr;
+    }
+
+    pp_addr = &c->proxy_protocol->src_addr;
+
+    /* check if proxy_protocol_addr differs from remote_addr */
+    if (pp_addr->len == remote_addr->len
+        && ngx_strncmp(pp_addr->data, remote_addr->data, pp_addr->len) == 0)
+    {
+        goto use_remote_addr;
+    }
+
+    /* check if remote_addr is trusted via set_real_ip_from */
+    rlcf = ngx_http_get_module_loc_conf(r, ngx_http_realip_module);
+
+    /* from is the first field of ngx_http_realip_loc_conf_t */
+    from = *(ngx_array_t **) rlcf;
+
+    if (from == NULL) {
+        goto use_remote_addr;
+    }
+
+    if (ngx_cidr_match(c->sockaddr, from) != NGX_OK) {
+        goto use_remote_addr;
+    }
+
+    /* remote_addr is trusted, use proxy_protocol_addr */
+    v->len = pp_addr->len;
+    v->data = pp_addr->data;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    return NGX_OK;
+
+use_remote_addr:
+
+    v->len = remote_addr->len;
+    v->data = remote_addr->data;
+    v->valid = 1;
+    v->no_cacheable = 0;
+    v->not_found = 0;
+
+    return NGX_OK;
+}
+#endif
+
+
 static ngx_http_variable_t  ngx_http_lua_kong_variables[] = {
 
     { ngx_string("kong_request_id"), NULL,
@@ -250,6 +319,10 @@ static ngx_http_variable_t  ngx_http_lua_kong_variables[] = {
     { ngx_string("kong_worker_connections_free"), NULL,
       ngx_http_lua_kong_variable_worker_connections_free,
       0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+#if (NGX_HTTP_REALIP)
+    { ngx_string("kong_client_addr"), NULL,
+      ngx_http_lua_kong_variable_client_addr, 0, 0, 0 },
+#endif
       ngx_http_null_variable
 };
 

--- a/t/013-realip-remote-addr.t
+++ b/t/013-realip-remote-addr.t
@@ -1,0 +1,157 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 5);
+
+my $pwd = cwd();
+
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+
+no_long_string();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: no proxy protocol, returns remote_addr
+--- http_config
+    set_real_ip_from 127.0.0.1;
+    real_ip_header proxy_protocol;
+--- config
+    location /t {
+        content_by_lua_block {
+            ngx.say(ngx.var.kong_client_addr)
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+=== TEST 2: proxy_protocol_addr set, remote_addr trusted, returns proxy_protocol_addr
+--- http_config
+    server {
+        listen 1985 proxy_protocol;
+        set_real_ip_from 127.0.0.1;
+        real_ip_header proxy_protocol;
+
+        location /pp {
+            content_by_lua_block {
+                ngx.say(ngx.var.kong_client_addr)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(5000)
+            assert(sock:connect("127.0.0.1", 1985))
+
+            sock:send("PROXY TCP4 192.168.1.1 127.0.0.1 12345 1985\r\n"
+                   .. "GET /pp HTTP/1.0\r\nHost: localhost\r\n\r\n")
+
+            local data = assert(sock:receive("*a"))
+            sock:close()
+
+            local body = data:match("\r\n\r\n(.+)")
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+192.168.1.1
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+=== TEST 3: proxy_protocol_addr same as remote_addr, returns remote_addr
+--- http_config
+    server {
+        listen 1985 proxy_protocol;
+        set_real_ip_from 127.0.0.1;
+        real_ip_header proxy_protocol;
+
+        location /pp {
+            content_by_lua_block {
+                ngx.say(ngx.var.kong_client_addr)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(5000)
+            assert(sock:connect("127.0.0.1", 1985))
+
+            sock:send("PROXY TCP4 127.0.0.1 127.0.0.1 12345 1985\r\n"
+                   .. "GET /pp HTTP/1.0\r\nHost: localhost\r\n\r\n")
+
+            local data = assert(sock:receive("*a"))
+            sock:close()
+
+            local body = data:match("\r\n\r\n(.+)")
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+--- no_error_log
+[error]
+[crit]
+[alert]
+
+
+=== TEST 4: proxy_protocol_addr set, remote_addr NOT trusted, returns remote_addr
+--- http_config
+    server {
+        listen 1985 proxy_protocol;
+        set_real_ip_from 10.0.0.0/8;
+        real_ip_header proxy_protocol;
+
+        location /pp {
+            content_by_lua_block {
+                ngx.say(ngx.var.kong_client_addr)
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(5000)
+            assert(sock:connect("127.0.0.1", 1985))
+
+            sock:send("PROXY TCP4 192.168.1.1 127.0.0.1 12345 1985\r\n"
+                   .. "GET /pp HTTP/1.0\r\nHost: localhost\r\n\r\n")
+
+            local data = assert(sock:receive("*a"))
+            sock:close()
+
+            local body = data:match("\r\n\r\n(.+)")
+            ngx.print(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+--- no_error_log
+[error]
+[crit]
+[alert]


### PR DESCRIPTION
Add a new nginx variable $kong_client_addr that returns the effective client IP address by considering the PROXY protocol header.

```lua
      local client_ip
      if var.proxy_protocol_addr and var.proxy_protocol_addr ~= var.remote_addr then
        if kong.ip.is_trusted(var.remote_addr) then
          client_ip = var.proxy_protocol_addr
        end
      end
```

The logic mirrors the existing Lua implementation:
- If proxy_protocol_addr is set and differs from remote_addr, and remote_addr is trusted per set_real_ip_from, return proxy_protocol_addr
- Otherwise return remote_addr

The trusted CIDR list is read from the http_realip module's loc conf by casting the first field (ngx_array_t *from) directly, avoiding the need to replicate the ngx_http_realip_loc_conf_t struct definition.

The variable is guarded by #if (NGX_HTTP_REALIP) and is included in the default indexed variable set when --with-http_realip_module is compiled.

- src/ngx_http_lua_kong_vars.c: implement handler
- src/ngx_http_lua_kong_var_index.c: add to default indexed vars
- README.md: document the new variable
- t/013-realip-remote-addr.t: add tests for all branch conditions

FTI-7344