### PR TITLE
test(request): demonstrate pending empty HTTP/2 bodies

### DIFF
--- a/t/014-req-had-body-http2.t
+++ b/t/014-req-had-body-http2.t
@@ -51,6 +51,21 @@ our $Config = <<'_EOC_';
             ngx.say(request.had_body())
         }
     }
+
+    # Observe the request before and after nginx parses the frame that ends
+    # an empty stream. This exposes the pending state hidden by the boolean API.
+    location = /pending {
+        content_by_lua_block {
+            local request = require("resty.kong.request")
+
+            local before_read = request.had_body()   # should be false
+            ngx.req.read_body()
+            local after_read = request.had_body()
+
+            ngx.say(before_read, ":", after_read, ":",
+                    ngx.req.get_body_data() or "")
+        }
+    }
 _EOC_
 
 add_block_preprocessor(sub {
@@ -181,6 +196,49 @@ POST /read
 invali
 --- response_body
 true:invali
+--- error_code: 200
+--- no_error_log
+[error]
+http v2 not supported yet
+
+
+=== TEST 10: pending stream ends with an empty DATA frame
+# /dev/null is a non-regular file, so curl starts an upload without a known
+# length. It sends HEADERS without END_STREAM, followed by a zero-length DATA
+# frame with END_STREAM. nginx runs the content phase between those frames.
+# Test::Nginx passes curl_options as one argv item. The full curl form is
+# "--upload-file /dev/null", so this test uses its compact -T/dev/null form.
+# The request has no body, so had_body() must remain false before and after
+# read_body(). The current boolean API reports true while the stream is pending.
+--- http2
+--- curl_options: -T/dev/null
+--- more_headers
+Content-Type:
+Content-Length:
+--- request
+POST /pending
+--- response_body
+false:false:
+--- error_code: 200
+--- no_error_log
+[error]
+http v2 not supported yet
+
+
+=== TEST 11: empty --data-binary ends a pending stream
+# Test::Nginx cannot pass the two argv items in "--data-binary ''". For an
+# empty payload, the compact -d@/dev/null form has the same wire behavior.
+# curl sends HEADERS without END_STREAM, then an empty DATA with END_STREAM.
+# The request has no body, so the result must be false in both states.
+--- http2
+--- curl_options: -d@/dev/null
+--- more_headers
+Content-Type:
+Content-Length:
+--- request
+POST /pending
+--- response_body
+false:false:
 --- error_code: 200
 --- no_error_log
 [error]


### PR DESCRIPTION
## Summary

This PR adds two HTTP/2 counterexamples for #122. Both send HEADERS without END_STREAM, followed by an empty DATA frame with END_STREAM.

The completed request body is empty, so `had_body()` should return `false` before and after `ngx.req.read_body()`. The current implementation returns `true:false:` because it maps the pending stream to `true`.

## Cases

- curl with `--upload-file /dev/null`
- curl with an empty `--data-binary` payload

## Protocol evidence

[RFC 9113 Section 6.2](https://datatracker.ietf.org/doc/html/rfc9113#section-6.2) defines END_STREAM on HEADERS as the stream-ending signal. Without this flag, the stream is only open; body bytes are not guaranteed. [Section 6.9.1](https://datatracker.ietf.org/doc/html/rfc9113#section-6.9.1) explicitly permits an empty DATA frame with END_STREAM. [Section 8.1](https://datatracker.ietf.org/doc/html/rfc9113#section-8.1) also states that HTTP/2 does not use HTTP/1.1 chunked transfer encoding.

Therefore, Nginx's internal `r->headers_in.chunked = 1` value is a pending-state marker in this case. It does not prove that body bytes exist. The boolean API cannot distinguish "body bytes exist" from "body bytes can still arrive."

## Tests

The test failures are expected. Both counterexamples expect `false:false:`, but the current implementation returns `true:false:`. This mismatch demonstrates the pending-state ambiguity that this PR reports. Each case runs twice, so CI reports four failed assertions. The remaining assertions pass.

This PR is not ready to merge until the API represents or resolves the pending state.
